### PR TITLE
Twin Suns design system overhaul + wishlist feature

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,9 +4,10 @@
     {
       "name": "Frontend (Next.js)",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeArgs": ["run", "dev", "--", "-p", "3001"],
       "cwd": "frontend",
-      "port": 3000
+      "port": 3001,
+      "autoPort": false
     },
     {
       "name": "Backend (FastAPI)",

--- a/backend/src/database/models.py
+++ b/backend/src/database/models.py
@@ -24,6 +24,7 @@ class User(Base):
     
     decks = relationship("Deck", back_populates="user", cascade="all, delete-orphan")
     collection = relationship("UserCollection", back_populates="user", cascade="all, delete-orphan")
+    wishlist = relationship("UserWishlist", back_populates="user", cascade="all, delete-orphan")
 
 print(f"--- Defining Deck class in models.py using Base ID: {id(Base)} ---")
 
@@ -93,6 +94,7 @@ class Card(Base):
     price_history = relationship("PriceHistory", back_populates="card", cascade="all, delete-orphan")
     deck_entries = relationship("DeckCard", back_populates="card")
     collectors = relationship("UserCollection", back_populates="card")
+    wishlist_entries = relationship("UserWishlist", back_populates="card")
 
 class CardAspect(Base):
     __tablename__ = 'card_aspects'
@@ -144,13 +146,23 @@ class PriceHistory(Base):
 
 class UserCollection(Base):
     __tablename__ = 'user_collection'
-    
+
     user_id = Column(String, ForeignKey('users.id'), primary_key=True)
     card_id = Column(String, ForeignKey('cards.id'), primary_key=True)
     count = Column(Integer, nullable=False, default=1)
-    
+
     user = relationship("User", back_populates="collection")
     card = relationship("Card", back_populates="collectors")
+
+class UserWishlist(Base):
+    __tablename__ = 'user_wishlist'
+
+    user_id = Column(String, ForeignKey('users.id'), primary_key=True)
+    card_id = Column(String, ForeignKey('cards.id'), primary_key=True)
+    added_at = Column(DateTime, default=datetime.datetime.utcnow)
+
+    user = relationship("User", back_populates="wishlist")
+    card = relationship("Card", back_populates="wishlist_entries")
 
 print(f"--- Finished defining models in models.py ---")
 print(f"--- Tables known to models.Base.metadata: {list(Base.metadata.tables.keys())} ---")

--- a/backend/src/routes/me.py
+++ b/backend/src/routes/me.py
@@ -4,7 +4,7 @@ from sqlalchemy import func, text
 from typing import List, Annotated
 import uuid
 from src.database.db import get_app_db, get_card_db
-from src.database.models import User, Deck, DeckCard, Card, UserCollection
+from src.database.models import User, Deck, DeckCard, Card, UserCollection, UserWishlist
 from src.auth.auth import get_current_user
 import logging
 
@@ -728,4 +728,101 @@ async def get_user_collection(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch collection"
+        )
+
+@router.get("/wishlist")
+async def get_user_wishlist(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_app_db)]
+):
+    """Get the wishlist for the logged-in user"""
+    try:
+        items = db.query(UserWishlist).filter(
+            UserWishlist.user_id == current_user.id
+        ).order_by(UserWishlist.added_at.desc()).all()
+
+        if not items:
+            return []
+
+        card_db_gen = get_card_db()
+        card_db = next(card_db_gen)
+        try:
+            result = []
+            for item in items:
+                card_query = text("SELECT * FROM cards WHERE id = :card_id")
+                card_proxy = card_db.execute(card_query, {"card_id": item.card_id})
+                if card_proxy.returns_rows:
+                    card_row = card_proxy.fetchone()
+                    if card_row:
+                        card_dict = {key: card_row._mapping[key] for key in card_row._mapping.keys()}
+                        card_with_relations = enrich_card_with_relationships(card_db, card_dict)
+                        result.append({
+                            "card": card_with_relations,
+                            "added_at": item.added_at.isoformat() if item.added_at else None,
+                        })
+            return result
+        finally:
+            card_db.close()
+    except Exception as e:
+        logger.error(f"Error fetching wishlist: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch wishlist"
+        )
+
+
+@router.post("/wishlist", status_code=status.HTTP_200_OK)
+async def add_to_wishlist(
+    request: Request,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_app_db)]
+):
+    """Add a card to the user's wishlist (idempotent)"""
+    try:
+        body = await request.json()
+        card_id = body.get("card_id")
+        if not card_id:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing card_id")
+
+        existing = db.query(UserWishlist).filter(
+            UserWishlist.user_id == current_user.id,
+            UserWishlist.card_id == card_id
+        ).first()
+
+        if not existing:
+            db.add(UserWishlist(user_id=current_user.id, card_id=card_id))
+            db.commit()
+
+        return {"success": True, "card_id": card_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error adding to wishlist: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to add to wishlist"
+        )
+
+
+@router.delete("/wishlist/{card_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_from_wishlist(
+    card_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_app_db)]
+):
+    """Remove a card from the user's wishlist"""
+    try:
+        db.query(UserWishlist).filter(
+            UserWishlist.user_id == current_user.id,
+            UserWishlist.card_id == card_id
+        ).delete()
+        db.commit()
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error removing from wishlist: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to remove from wishlist"
         )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "framer-motion": "^12.5.0",
         "lodash-es": "^4.17.21",
         "lucide-react": "^0.483.0",
-        "next": "15.2.3",
+        "next": "^15.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^3.3.1"
@@ -34,12 +34,12 @@
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
-        "@types/react": "^19.0.12",
+        "@types/react": "19.2.14",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.2.3",
         "tailwindcss": "^4.0.15",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -330,10 +330,20 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -349,13 +359,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -371,13 +381,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -391,9 +401,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -407,9 +417,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -423,9 +433,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -438,10 +448,42 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -455,9 +497,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -471,9 +513,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -487,9 +529,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -503,9 +545,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -521,13 +563,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -543,13 +585,57 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -565,13 +651,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -587,13 +673,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -609,13 +695,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -631,20 +717,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -653,10 +739,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -673,9 +778,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -705,9 +810,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.3.tgz",
-      "integrity": "sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -721,9 +826,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
-      "integrity": "sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -737,9 +842,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
-      "integrity": "sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -753,9 +858,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
-      "integrity": "sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -769,9 +874,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
-      "integrity": "sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -785,9 +890,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz",
-      "integrity": "sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -801,9 +906,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz",
-      "integrity": "sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -817,9 +922,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
-      "integrity": "sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -833,9 +938,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
-      "integrity": "sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -2770,12 +2875,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3080,13 +3179,13 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
-      "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
@@ -3100,21 +3199,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.27.0.tgz",
-      "integrity": "sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/type-utils": "8.27.0",
-        "@typescript-eslint/utils": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3124,23 +3222,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.27.0.tgz",
-      "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/typescript-estree": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3150,19 +3258,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
-      "integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3172,17 +3302,35 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.27.0.tgz",
-      "integrity": "sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.27.0",
-        "@typescript-eslint/utils": "8.27.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3192,14 +3340,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
-      "integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3211,20 +3359,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
-      "integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3234,76 +3383,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
-      "integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/typescript-estree": "8.27.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3313,19 +3445,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
-      "integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3333,6 +3465,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
@@ -3819,17 +3964,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3954,25 +4088,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3985,19 +4105,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4022,9 +4131,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -4090,9 +4199,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4151,9 +4260,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5179,13 +5288,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5349,13 +5451,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6276,15 +6371,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.3.tgz",
-      "integrity": "sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.3",
-        "@swc/counter": "0.1.3",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
-        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -6296,19 +6389,19 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.3",
-        "@next/swc-darwin-x64": "15.2.3",
-        "@next/swc-linux-arm64-gnu": "15.2.3",
-        "@next/swc-linux-arm64-musl": "15.2.3",
-        "@next/swc-linux-x64-gnu": "15.2.3",
-        "@next/swc-linux-x64-musl": "15.2.3",
-        "@next/swc-win32-arm64-msvc": "15.2.3",
-        "@next/swc-win32-x64-msvc": "15.2.3",
-        "sharp": "^0.33.5"
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.51.1",
         "babel-plugin-react-compiler": "*",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -7008,9 +7101,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -7070,16 +7163,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -7088,25 +7181,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -7208,16 +7306,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7233,14 +7321,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -7455,14 +7535,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7472,11 +7552,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -7487,9 +7570,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7513,9 +7596,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7636,9 +7719,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,11 +35,11 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
-    "@types/react": "^19.0.12",
+    "@types/react": "19.2.14",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "tailwindcss": "^4.0.15",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/frontend/src/app/api/me/wishlist/[cardId]/route.ts
+++ b/frontend/src/app/api/me/wishlist/[cardId]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const API_URL = process.env.INTERNAL_API_URL || 'http://localhost:8000';
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ cardId: string }> }
+) {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get('auth_token');
+    if (!token?.value) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    const { cardId } = await params;
+    const response = await fetch(`${API_URL}/api/me/wishlist/${cardId}`, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${token.value}` },
+    });
+    if (response.status === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
+    if (!response.ok) {
+      return NextResponse.json({ detail: 'Error removing from wishlist' }, { status: response.status });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Error in DELETE /api/me/wishlist/[cardId]:', error);
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/me/wishlist/route.ts
+++ b/frontend/src/app/api/me/wishlist/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const API_URL = process.env.INTERNAL_API_URL || 'http://localhost:8000';
+
+async function getToken() {
+  const cookieStore = await cookies();
+  return cookieStore.get('auth_token');
+}
+
+export async function GET() {
+  try {
+    const token = await getToken();
+    if (!token?.value) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    const response = await fetch(`${API_URL}/api/me/wishlist`, {
+      headers: { 'Authorization': `Bearer ${token.value}` },
+    });
+    if (!response.ok) {
+      return NextResponse.json({ detail: 'Error fetching wishlist' }, { status: response.status });
+    }
+    return NextResponse.json(await response.json());
+  } catch (error) {
+    console.error('Error in GET /api/me/wishlist:', error);
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await getToken();
+    if (!token?.value) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    const body = await request.json();
+    const response = await fetch(`${API_URL}/api/me/wishlist`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token.value}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      return NextResponse.json({ detail: 'Error updating wishlist' }, { status: response.status });
+    }
+    return NextResponse.json(await response.json());
+  } catch (error) {
+    console.error('Error in POST /api/me/wishlist:', error);
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/deck-builder/DeckBuilderClient.tsx
+++ b/frontend/src/app/deck-builder/DeckBuilderClient.tsx
@@ -3,1009 +3,1492 @@
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { CardGrid } from '@/components/CardGrid';
-import { CardDetail } from '@/components/CardDetail';
-import { LeaderSelection } from '@/components/LeaderSelection';
-import { DeckStats } from '@/components/DeckStats';
-import SaveDeckDialog from '@/components/SaveDeckDialog';
 import { useDeckBuilder } from '@/contexts/DeckBuilderContext';
-import { Card as CardType, FetchCardsParams, fetchCards, fetchAspects, fetchKeywords, fetchSets, fetchTraits, SavedDeck } from '@/lib/api';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
+import { Card as CardType, FetchCardsParams, fetchCards, fetchAspects, fetchSets, fetchTraits, SavedDeck } from '@/lib/api';
 import { debounce } from 'lodash-es';
 import { fetchWithAuth } from '@/lib/fetch-utils';
 import { useAuth } from '@/contexts/AuthContext';
+import SaveDeckDialog from '@/components/SaveDeckDialog';
+import { HandSimModal } from './HandSimModal';
 
-// Type for individual items in the deck's card list from context/backend
-interface DeckCardItem {
-    card: CardType;
-    quantity: number;
-}
-
-// Constants
+// ── Constants ──────────────────────────────────────────────
 const SEARCH_DEBOUNCE_MS = 400;
-const CARDS_PER_PAGE = 50;
+const CARDS_PER_PAGE = 60;
 const LOOP_CHECK_WINDOW_MS = 3000;
 const MAX_VISITS_IN_WINDOW = 10;
 
-// Memoized CardDetail component
-const MemoizedCardDetail = React.memo(CardDetail);
+// ── Aspect pip ─────────────────────────────────────────────
+function AspectPip({ aspect }: { aspect: string }) {
+  const initials: Record<string, string> = {
+    Command: 'C', Aggression: 'A', Cunning: 'U',
+    Heroism: 'H', Vigilance: 'V', Villainy: 'X',
+  };
+  return (
+    <span
+      className="ts-aspect-pip"
+      data-aspect={aspect}
+      title={aspect}
+      style={{ width: 18, height: 18, fontSize: 8 }}
+    >
+      {initials[aspect] ?? aspect[0]}
+    </span>
+  );
+}
 
-export default function DeckBuilderClient() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const deckIdParam = searchParams.get('deckId');
-    const { isAuthenticated, isLoading: authLoading } = useAuth();
+// ── Resource curve chart ───────────────────────────────────
+function ResourceCurveChart({ deckCards }: { deckCards: { card: CardType; quantity: number }[] }) {
+  const curve = Array(8).fill(0);
+  deckCards.forEach(({ card, quantity }) => {
+    const cost = card.cost ?? card.energy_cost ?? 0;
+    const i = Math.min(cost, 7);
+    curve[i] += quantity;
+  });
+  const maxBar = Math.max(...curve, 1);
+  const labels = ['0','1','2','3','4','5','6','7+'];
 
-    // Redirect unauthenticated users to login
-    useEffect(() => {
-        if (!authLoading && !isAuthenticated) {
-            router.push('/login?redirect=/deck-builder');
-        }
-    }, [authLoading, isAuthenticated, router]);
-
-    // --- State ---
-    const [isPotentialLoop, setIsPotentialLoop] = useState(false);
-    const [cards, setCards] = useState<CardType[]>([]);
-    const [selectedCard, setSelectedCard] = useState<CardType | null>(null);
-    const [loading, setLoading] = useState(!deckIdParam);
-    const [isLoadingMore, setIsLoadingMore] = useState(false);
-    const [loadingDeck, setLoadingDeck] = useState(!!deckIdParam);
-    const [error, setError] = useState<string | null>(null);
-    const [searchQuery, setSearchQuery] = useState<string>('');
-    const [cardTypeFilter, setCardTypeFilter] = useState<string>('');
-    const [showAllCards, setShowAllCards] = useState<boolean>(false);
-    const [hideCardsInDeck, setHideCardsInDeck] = useState(true);
-    const [showSaveDialog, setShowSaveDialog] = useState(false);
-    const [currentPage, setCurrentPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(1);
-    const [hasMoreCards, setHasMoreCards] = useState(true);
-    const [deckLoaded, setDeckLoaded] = useState(false);
-
-    // --- Filter + Sort State (cards stage only) ---
-    const [filterAspects, setFilterAspects] = useState<string[]>([]);
-    const [filterKeywords, setFilterKeywords] = useState<string[]>([]);
-    const [filterTraits, setFilterTraits] = useState<string[]>([]);
-    const [filterSets, setFilterSets] = useState<string[]>([]);
-    const [sortBy, setSortBy] = useState('name_asc');
-    const [showFilters, setShowFilters] = useState(false);
-
-    // --- Filter option lists ---
-    const [availableAspects, setAvailableAspects] = useState<string[]>([]);
-    const [availableKeywords, setAvailableKeywords] = useState<string[]>([]);
-    const [availableTraits, setAvailableTraits] = useState<string[]>([]);
-    const [availableSets, setAvailableSets] = useState<string[]>([]);
-
-    // --- Refs ---
-    const loadingRef = useRef(false);
-    const observerRef = useRef<IntersectionObserver | null>(null);
-    const lastCardElementRef = useRef<HTMLDivElement | null>(null);
-    const cardLoadingStageRef = useRef<string | null>(null);
-
-    // --- Deck Builder Context ---
-    const {
-        currentStage, leaders, base, deckCards, deckName,
-        addLeader, removeLeader, setBase: setBaseContext, addCard, removeCard,
-        setDeckName, isCardInDeck: isCardIdInDeck, isCardInAspect, resetDeck,
-        setCurrentStage: contextSetCurrentStage
-    } = useDeckBuilder();
-
-    // --- Loop Detection Effect ---
-    useEffect(() => {
-        const visitTimestamp = Date.now();
-        let visitHistory: number[] = [];
-        try { 
-            visitHistory = JSON.parse(sessionStorage.getItem('deckBuilderVisitHistory') || '[]'); 
-        } catch (e) { 
-            console.error("Failed to parse deckBuilderVisitHistory, resetting.", e); 
-            visitHistory = []; 
-        }
-
-        const recentVisits = visitHistory.filter((ts: number) => visitTimestamp - ts < LOOP_CHECK_WINDOW_MS);
-        recentVisits.push(visitTimestamp);
-        sessionStorage.setItem('deckBuilderVisitHistory', JSON.stringify(recentVisits));
-
-        if (recentVisits.length > MAX_VISITS_IN_WINDOW) {
-            console.error(`[DEBUG] Potential Loop Detected: ${recentVisits.length} renders in ${LOOP_CHECK_WINDOW_MS}ms. Halting potentially problematic operations.`);
-            setIsPotentialLoop(true);
-            sessionStorage.removeItem('deckBuilderVisitHistory');
-            sessionStorage.removeItem('editingDeck');
-            sessionStorage.removeItem('lastEditAttempt');
-            sessionStorage.removeItem('processedDeckId');
-        }
-        
-        const clearTimer = setTimeout(() => {
-            let currentHistory: number[] = [];
-            try { 
-                currentHistory = JSON.parse(sessionStorage.getItem('deckBuilderVisitHistory') || '[]'); 
-            } catch {}
-            const lastVisit = currentHistory[currentHistory.length - 1];
-            if (lastVisit && Date.now() - lastVisit > LOOP_CHECK_WINDOW_MS) { 
-                sessionStorage.removeItem('deckBuilderVisitHistory'); 
-            }
-        }, LOOP_CHECK_WINDOW_MS + 2000);
-        
-        return () => clearTimeout(clearTimer);
-    }, []);
-
-    // --- Load filter options when entering cards stage ---
-    useEffect(() => {
-        if (currentStage !== 'cards' || availableAspects.length > 0) return;
-        Promise.all([fetchAspects(), fetchKeywords(), fetchSets(), fetchTraits()])
-            .then(([asp, kw, sets, traits]) => {
-                setAvailableAspects(asp.map((a: any) => a.aspect_name).filter(Boolean));
-                setAvailableKeywords(kw.map((k: any) => k.keyword).filter(Boolean));
-                setAvailableSets(sets.map((s: any) => s.set_name).filter(Boolean));
-                setAvailableTraits(traits.map((t: any) => t.trait).filter(Boolean));
-            })
-            .catch(err => console.error('[DeckBuilder] Failed to load filter options:', err));
-    }, [currentStage, availableAspects.length]);
-
-    // --- Load Cards Function ---
-    const loadCards = useCallback(async (
-        page = 1,
-        append = false,
-        currentSearch = searchQuery,
-        aspects = filterAspects,
-        keywords = filterKeywords,
-        traits = filterTraits,
-        sets = filterSets,
-        sort = sortBy,
-    ) => {
-        if (loadingRef.current || (append && !hasMoreCards)) return;
-        loadingRef.current = true;
-        setError(null);
-
-        if (page === 1 && !append) setLoading(true);
-        else if (append) setIsLoadingMore(true);
-
-        console.log(`[API] Fetching cards: Stage=${currentStage}, Page=${page}, Append=${append}, Search='${currentSearch}'`);
-
-        const params: FetchCardsParams = {
-            page: page.toString(),
-            limit: CARDS_PER_PAGE.toString(),
-            search: currentSearch || undefined,
-        };
-
-        if (currentStage === 'leaders') params.type = 'Leader';
-        else if (currentStage === 'base') params.type = 'Base';
-        else if (currentStage === 'cards') {
-            params.type = 'Unit,Event,Upgrade';
-            if (aspects.length) params.aspect = aspects.join(',');
-            if (keywords.length) params.keyword = keywords.join(',');
-            if (traits.length) params.trait = traits.join(',');
-            if (sets.length) params.set = sets.join(',');
-            params.sort = sort;
-        }
-
-        try {
-            const response = await fetchCards(params);
-            const newCards = Array.isArray(response.data) ? response.data : [];
-            const meta = response.meta || { pages: 1, total: newCards.length };
-            
-            setCards(prev => append ? [...prev, ...newCards] : newCards);
-            setTotalPages(meta.pages || 1);
-            setHasMoreCards((meta.pages || 1) > page);
-            setCurrentPage(page);
-            
-            console.log(`[API] Successfully loaded ${newCards.length} cards for stage '${currentStage}'`);
-        } catch (err) {
-            console.error(`[API] Failed to load cards:`, err);
-            setError(`Failed to load cards: ${err instanceof Error ? err.message : 'Unknown error'}`);
-        } finally {
-            setLoading(false);
-            setIsLoadingMore(false);
-            loadingRef.current = false;
-        }
-    }, [currentStage, searchQuery, filterAspects, filterKeywords, filterTraits, filterSets, sortBy, hasMoreCards]);
-
-    // --- Load Existing Deck Effect ---
-    useEffect(() => {
-        if (!deckIdParam || isPotentialLoop) { 
-            console.log('[DEBUG] loadExistingDeck Effect: No deckIdParam or potential loop detected. Skipping.'); 
-            setLoadingDeck(false); 
-            return; 
-        }
-        
-        const processedDeckId = sessionStorage.getItem('processedDeckId');
-        
-        if (processedDeckId && processedDeckId !== deckIdParam) {
-            console.log(`[DEBUG] New deck ID detected (${deckIdParam}). Clearing processed flag for ${processedDeckId}.`);
-            sessionStorage.removeItem('processedDeckId');
-        } else if (processedDeckId === deckIdParam) {
-            console.log('[DEBUG] loadExistingDeck Effect: Already processed this deck ID, skipping reload.');
-            setLoadingDeck(false);
-            if (currentStage !== 'cards') { 
-                contextSetCurrentStage('cards'); 
-            }
-            return;
-        }
-
-        console.log('[DEBUG] loadExistingDeck Effect: Starting load for deck ID:', deckIdParam);
-
-        const loadExistingDeck = async () => {
-            setLoadingDeck(true); 
-            setError(null);
-            
-            try {
-                sessionStorage.setItem('processedDeckId', deckIdParam);
-                let attempts = 0; 
-                const maxAttempts = 3; 
-                let deckData: SavedDeck | null = null;
-
-                while (attempts < maxAttempts && !deckData) {
-                    attempts++;
-                    try {
-                        console.log(`[API] Load Deck Attempt ${attempts} for deck: ${deckIdParam}`);
-                        const fetchedData = await fetchWithAuth(`/api/me/get-deck?id=${encodeURIComponent(deckIdParam)}`);
-                        console.log('[DEBUG] loadExistingDeck: Received raw data:', JSON.stringify(fetchedData, null, 2));
-
-                        // Validate the fetched data structure
-                        if (fetchedData && 
-                            typeof fetchedData === 'object' && 
-                            fetchedData.id === deckIdParam && 
-                            Array.isArray(fetchedData.leaders) && 
-                            Array.isArray(fetchedData.cards)) {
-                            deckData = fetchedData as SavedDeck;
-                            break;
-                        } else {
-                            throw new Error('Invalid or incomplete deck data received from server.');
-                        }
-                    } catch (fetchError: any) {
-                        console.error(`[Error] Fetch attempt ${attempts} failed:`, fetchError);
-                        if (attempts === maxAttempts) throw fetchError;
-                        await new Promise(resolve => setTimeout(resolve, 1000 * attempts));
-                    }
-                }
-
-                // Process deckData if fetch succeeded
-                if (deckData) {
-                    console.log('[DEBUG] loadExistingDeck: Fetch successful. Updating context state...');
-                    console.log('[DEBUG] loadExistingDeck: Context state BEFORE:', { 
-                        name: deckName, 
-                        leaders: leaders.length, 
-                        base: !!base, 
-                        cards: deckCards.length, 
-                        stage: currentStage 
-                    });
-                    
-                    resetDeck();
-                    setDeckName(deckData.name || "Untitled Deck");
-                    
-                    // Add Leaders - deckData.leaders is already an array of Card objects
-                    if (Array.isArray(deckData.leaders)) {
-                        deckData.leaders.forEach((leader: CardType) => { 
-                            if (leader?.id) {
-                                addLeader(leader); 
-                            } else {
-                                console.error("[DEBUG] Invalid leader format:", leader); 
-                            }
-                        });
-                    }
-                    
-                    // Set Base - deckData.base is already a Card object or null
-                    if (deckData.base?.id) { 
-                        setBaseContext(deckData.base); 
-                    } else { 
-                        setBaseContext(null); 
-                    }
-                    
-                    // Add Cards - need to handle the backend format
-                    if (Array.isArray(deckData.cards)) {
-                        deckData.cards.forEach((cardItem: { card: CardType; quantity: number }) => {
-                            if (cardItem.card?.id) {
-                                addCard(cardItem.card);
-                            } else {
-                                console.error("[DEBUG] Invalid card format - missing card data:", cardItem);
-                            }
-                        });
-                    }
-                    
-                    contextSetCurrentStage('cards');
-                    console.log("[DEBUG] loadExistingDeck: Context updated and stage set to 'cards'");
-                    setDeckLoaded(true);
-                    
-                    setTimeout(() => { 
-                        console.log('[DEBUG] loadExistingDeck: Context state AFTER (delayed):', { 
-                            name: deckName, 
-                            leaders: leaders.length, 
-                            base: !!base, 
-                            cards: deckCards.length, 
-                            stage: currentStage 
-                        }); 
-                    }, 100);
-                } else {
-                    throw new Error("Failed to fetch valid deck data after multiple attempts.");
-                }
-            } catch (err) {
-                console.error('[DEBUG] Final error in loadExistingDeck process:', err);
-                if (err instanceof Error && err.message?.includes('(401)')) { 
-                    setError('Unauthorized loading deck. Please log in again.'); 
-                } else { 
-                    setError(`Failed to load deck: ${err instanceof Error ? err.message : 'Unknown error'}`); 
-                }
-                sessionStorage.removeItem('processedDeckId');
-                setDeckLoaded(false);
-            } finally {
-                setLoadingDeck(false);
-            }
-        };
-        
-        loadExistingDeck();
-
-        return () => { 
-            console.log('[DEBUG] Cleanup for loadExistingDeck effect'); 
-        };
-    }, [deckIdParam, isPotentialLoop, resetDeck, setDeckName, addLeader, setBaseContext, addCard, contextSetCurrentStage]);
-
-    // --- Load Cards Effect ---
-    useEffect(() => {
-        if (isPotentialLoop) return;
-
-        const stageKey = `${currentStage}-${searchQuery}-${filterAspects.join(',')}-${filterKeywords.join(',')}-${filterTraits.join(',')}-${filterSets.join(',')}-${sortBy}`;
-        if (cardLoadingStageRef.current === stageKey) return;
-
-        cardLoadingStageRef.current = stageKey;
-        console.log(`[Cards] Loading cards for stage: ${currentStage}, search: "${searchQuery}"`);
-
-        setCards([]);
-        setCurrentPage(1);
-        setHasMoreCards(true);
-        loadCards(1, false, searchQuery, filterAspects, filterKeywords, filterTraits, filterSets, sortBy);
-    }, [currentStage, searchQuery, filterAspects, filterKeywords, filterTraits, filterSets, sortBy, loadCards, isPotentialLoop]);
-
-    // --- Debounced Search ---
-    const debouncedSearch = useMemo(
-        () => debounce((query: string) => {
-            console.log(`[Search] Debounced search triggered: "${query}"`);
-            setSearchQuery(query);
-        }, SEARCH_DEBOUNCE_MS),
-        []
-    );
-
-    // --- Event Handlers ---
-    const handleCardClick = useCallback((card: CardType) => { 
-        setSelectedCard(card); 
-    }, []);
-
-    const handleCardDoubleClick = useCallback((card: CardType) => {
-        if (currentStage === 'leaders') { 
-            if (leaders.length < 2 && !leaders.some(l => l.id === card.id)) {
-                addLeader(card); 
-            }
-        } else if (currentStage === 'base') { 
-            if (card.type === 'Base' && !base) {
-                setBaseContext(card); 
-            }
-        } else if (currentStage === 'cards') { 
-            if (!isCardIdInDeck(card.id)) {
-                addCard(card); 
-            }
-        }
-    }, [currentStage, leaders, base, addLeader, setBaseContext, addCard, isCardIdInDeck]);
-
-    const handleAddToDeck = useCallback((card: CardType) => { 
-        handleCardDoubleClick(card); 
-    }, [handleCardDoubleClick]);
-
-    const handleRemoveFromDeck = useCallback((cardId: string) => {
-        if (leaders.some(l => l.id === cardId)) {
-            removeLeader(cardId);
-        } else if (base?.id === cardId) {
-            setBaseContext(null);
-        } else {
-            removeCard(cardId);
-        }
-        if (selectedCard?.id === cardId) {
-            setSelectedCard(null);
-        }
-    }, [leaders, base, removeLeader, setBaseContext, removeCard, selectedCard]);
-
-    const loadMoreCardsHandler = useCallback(() => {
-        if (hasMoreCards && !isLoadingMore) {
-            loadCards(currentPage + 1, true, searchQuery, filterAspects, filterKeywords, filterTraits, filterSets, sortBy);
-        }
-    }, [hasMoreCards, isLoadingMore, currentPage, searchQuery, filterAspects, filterKeywords, filterTraits, filterSets, sortBy, loadCards]);
-
-    // --- Helper function to check if leaders share aspects ---
-    const leadersShareAspects = useCallback((leader1: CardType, leader2: CardType): boolean => {
-        const aspects1 = leader1.aspects?.map(a => a.aspect_name) || [];
-        const aspects2 = leader2.aspects?.map(a => a.aspect_name) || [];
-
-        // Heroism and Villainy cannot coexist in the same deck
-        if (aspects1.includes('Heroism') && aspects2.includes('Villainy')) return false;
-        if (aspects1.includes('Villainy') && aspects2.includes('Heroism')) return false;
-
-        // Leaders must share at least one aspect in Twin Suns format
-        return aspects1.some(aspect => aspects2.includes(aspect));
-    }, []);
-
-
-    // --- Client-Side Filtering ---
-    const displayedCards = useMemo(() => {
-    let filtered = cards;
-    
-    // Filter leaders based on compatibility with first selected leader
-    if (currentStage === 'leaders' && leaders.length === 1) {
-        const firstLeader = leaders[0];
-        filtered = filtered.filter(card => {
-            // Don't show the already selected leader
-            if (card.id === firstLeader.id) return false;
-            
-            // Only show leaders that share at least one aspect with the first leader
-            return leadersShareAspects(firstLeader, card);
-        });
-    }
-    
-    // Filter out leaders that are already selected (when browsing all leaders)
-    if (currentStage === 'leaders') {
-        const selectedLeaderIds = new Set(leaders.map(l => l.id));
-        filtered = filtered.filter(card => !selectedLeaderIds.has(card.id));
-    }
-    
-    // Existing filtering logic
-    if (currentStage === 'cards' && hideCardsInDeck) { 
-        const deckCardIds = new Set(deckCards.map(dc => dc.card.id)); 
-        filtered = filtered.filter(card => !deckCardIds.has(card.id)); 
-    }
-    
-    if (currentStage === 'cards' && !showAllCards && leaders.length === 2 && base) { 
-        filtered = filtered.filter(card => isCardInAspect(card)); 
-    }
-    
-    if (cardTypeFilter && cardTypeFilter !== 'All') { 
-        filtered = filtered.filter(card => card.type?.toLowerCase() === cardTypeFilter.toLowerCase()); 
-    }
-    
-    return filtered;
-}, [cards, hideCardsInDeck, deckCards, currentStage, showAllCards, leaders, base, cardTypeFilter, isCardInAspect, leadersShareAspects]);
-
-    // --- UI Helper Functions ---
-    const getStageInfo = useCallback(() => {
-        switch (currentStage) {
-            case 'leaders': 
-                return { title: 'Select Leaders', description: 'Choose two leaders for your deck.' };
-            case 'base': 
-                return { title: 'Select Base', description: 'Choose a base for your deck.' };
-            case 'cards': 
-                return { title: 'Add Cards', description: 'Add cards to your deck.' };
-            default: 
-                return { title: 'Deck Builder', description: 'Build your deck.' };
-        }
-    }, [currentStage]);
-
-    // --- Render Functions ---
-    const renderLeaderSelectionArea = useCallback(() => (
-        <Card className="bg-gray-900 border-gray-800">
-            <CardHeader className="border-b border-gray-800 p-4">
-                <CardTitle className="text-xl">Your Leaders ({leaders.length}/2)</CardTitle>
-            </CardHeader>
-            <CardContent className="p-4">
-                {leaders.length > 0 ? (
-                    <div className="grid grid-cols-2 gap-4">
-                        {leaders.map((leader) => (
-                            <div key={`leader-${leader.id}`} className="relative max-w-xs group cursor-pointer" onClick={() => setSelectedCard(leader)}>
-                                <div className="aspect-[7/10] relative rounded-lg overflow-hidden border-2 border-purple-500 bg-gray-800">
-                                    <img 
-                                        src={leader.image_uri ?? '/placeholder-card.png'} 
-                                        alt={leader.name} 
-                                        className="w-full h-full object-contain" 
-                                        onError={(e) => { 
-                                            const target = e.target as HTMLImageElement; 
-                                            target.src = '/placeholder-card.png'; 
-                                        }}
-                                    />
-                                </div>
-                                <button 
-                                    className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity z-10" 
-                                    onClick={(e) => { 
-                                        e.stopPropagation(); 
-                                        handleRemoveFromDeck(leader.id); 
-                                    }}
-                                >
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                                <div className="mt-2 text-center">
-                                    <h3 className="font-medium truncate" title={leader.name}>{leader.name}</h3>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                ) : (
-                    <div className="h-40 flex items-center justify-center text-gray-500">
-                        Select two leaders from the cards above.
-                    </div>
-                )}
-                <div className="mt-6 flex justify-between">
-                    <Button onClick={resetDeck} variant="destructive">Reset Deck</Button>
-                    <Button 
-                        onClick={() => contextSetCurrentStage('base')} 
-                        disabled={leaders.length !== 2} 
-                        className="bg-gradient-to-r from-purple-600 to-purple-400 text-white hover:opacity-90 disabled:opacity-50"
-                    >
-                        Next: Select Base
-                    </Button>
-                </div>
-            </CardContent>
-        </Card>
-    ), [leaders, handleRemoveFromDeck, resetDeck, contextSetCurrentStage, setSelectedCard]);
-
-    const renderBaseSelectionArea = useCallback(() => (
-        <Card className="bg-gray-900 border-gray-800">
-            <CardHeader className="border-b border-gray-800 p-4">
-                <CardTitle className="text-xl">Your Base</CardTitle>
-            </CardHeader>
-            <CardContent className="p-4">
-                <div className="flex justify-center">
-                    {base ? (
-                        <div className="relative max-w-xs group cursor-pointer" onClick={() => setSelectedCard(base)}>
-                            <div className="aspect-[7/10] relative rounded-lg overflow-hidden border-2 border-purple-500 bg-gray-800">
-                                <img 
-                                    src={base.image_uri ?? '/placeholder-card.png'} 
-                                    alt={base.name} 
-                                    className="w-full h-full object-contain" 
-                                    onError={(e) => { 
-                                        const target = e.target as HTMLImageElement; 
-                                        target.src = '/placeholder-card.png'; 
-                                    }}
-                                />
-                            </div>
-                            <button 
-                                className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity z-10" 
-                                onClick={(e) => { 
-                                    e.stopPropagation(); 
-                                    handleRemoveFromDeck(base.id); 
-                                }}
-                            >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                </svg>
-                            </button>
-                            <div className="mt-2 text-center">
-                                <h3 className="font-medium truncate" title={base.name}>{base.name}</h3>
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="aspect-[7/10] rounded-lg border-2 border-dashed border-gray-700 flex items-center justify-center max-w-xs w-full text-gray-500">
-                            Select a Base
-                        </div>
-                    )}
-                </div>
-                <div className="mt-6 flex justify-between">
-                    <Button onClick={() => contextSetCurrentStage('leaders')} variant="outline">Back</Button>
-                    <Button onClick={resetDeck} variant="destructive">Reset Deck</Button>
-                    <Button 
-                        onClick={() => contextSetCurrentStage('cards')} 
-                        disabled={!base} 
-                        className="bg-gradient-to-r from-orange-600 to-orange-400 text-white hover:opacity-90 disabled:opacity-50"
-                    >
-                        Next: Add Cards
-                    </Button>
-                </div>
-            </CardContent>
-        </Card>
-    ), [base, handleRemoveFromDeck, resetDeck, contextSetCurrentStage, setSelectedCard]);
-
-    const renderCardsSelectionArea = useCallback(() => (
-        <Card className="bg-gray-900 border-gray-800">
-            <CardHeader className="border-b border-gray-800 p-4">
-                <CardTitle className="text-xl">Your Deck ({deckCards.length})</CardTitle>
-            </CardHeader>
-            <CardContent className="p-4">
-                {deckCards.length > 0 ? (
-                    <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-8 xl:grid-cols-9 gap-2">
-                        {deckCards.map((item: DeckCardItem) => { 
-                            const card = item.card; 
-                            if (!card) return null; 
-                            return (
-                                <div key={`deck-${card.id}`} className="relative group cursor-pointer" onClick={() => setSelectedCard(card)}>
-                                    <div className="aspect-[7/10] relative rounded-lg overflow-hidden border border-gray-700 hover:border-purple-500 transition-colors bg-gray-800">
-                                        <img 
-                                            src={card.image_uri ?? '/placeholder-card.png'} 
-                                            alt={card.name} 
-                                            className="w-full h-full object-contain" 
-                                            onError={(e) => { 
-                                                const target = e.target as HTMLImageElement; 
-                                                target.src = '/placeholder-card.png'; 
-                                            }}
-                                        />
-                                        <button 
-                                            className="absolute top-1 right-1 p-1 bg-red-600 hover:bg-red-700 rounded-full text-white opacity-0 group-hover:opacity-100 transition-opacity z-10" 
-                                            onClick={(e) => { 
-                                                e.stopPropagation(); 
-                                                handleRemoveFromDeck(card.id); 
-                                            }}
-                                        >
-                                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                            </svg>
-                                        </button>
-                                        <div className="absolute bottom-0 left-0 right-0 bg-black/70 text-xs p-1 truncate">
-                                            {card.name}
-                                        </div>
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                ) : (
-                    <div className="h-40 flex items-center justify-center text-gray-500">
-                        Add cards to your deck.
-                    </div>
-                )}
-                <div className="mt-6 flex flex-wrap justify-between items-start gap-4">
-                    <div>
-                        <Button onClick={() => contextSetCurrentStage('base')} variant="outline" className="mr-2">
-                            Back
-                        </Button>
-                        <Button onClick={resetDeck} variant="destructive">
-                            Reset Deck
-                        </Button>
-                    </div>
-                    <Button 
-                        onClick={() => setShowSaveDialog(true)} 
-                        className="bg-green-600 hover:bg-green-700 text-white" 
-                        disabled={leaders.length !== 2 || !base}
-                    >
-                        Save Deck
-                    </Button>
-                </div>
-                {(leaders.length > 0 || base || deckCards.length > 0) && (
-                    <div className="mt-6">
-                        <DeckStats />
-                    </div>
-                )}
-            </CardContent>
-        </Card>
-    ), [deckCards, handleRemoveFromDeck, resetDeck, contextSetCurrentStage, setSelectedCard, leaders, base]);
-
-    // --- Main Component Return ---
-    if (isPotentialLoop) {
-        return (
-            <div className="min-h-screen bg-black text-white flex items-center justify-center p-8">
-                <div className="text-center bg-red-900/50 border border-red-500 p-6 rounded-lg max-w-md">
-                    <h2 className="text-2xl text-red-300 mb-4">Potential Loop Detected</h2>
-                    <p className="text-red-200 mb-4">
-                        Too many rapid page renders occurred. Deck loading has been halted to prevent issues.
-                    </p>
-                    <Button 
-                        onClick={() => {
-                            sessionStorage.clear();
-                            window.location.reload();
-                        }} 
-                        variant="outline" 
-                        className="border-red-400 text-red-300 hover:bg-red-900/50"
-                    >
-                        Clear Cache & Reload
-                    </Button>
-                </div>
-            </div>
-        );
-    }
-
-    const stageInfo = getStageInfo();
-
-    return (
-        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">
-            <div className="container mx-auto px-4 py-6">
-                {/* Header */}
-                <div className="mb-6">
-                    <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-400 to-orange-400 bg-clip-text text-transparent">
-                        Twin Suns Deck Builder
-                    </h1>
-                    <p className="text-gray-400 mt-2">{stageInfo.description}</p>
-                    {error && (
-                        <div className="mt-4 p-4 bg-red-900/50 border border-red-500 rounded-lg">
-                            <p className="text-red-300">{error}</p>
-                            <Button 
-                                onClick={() => setError(null)} 
-                                variant="outline" 
-                                size="sm" 
-                                className="mt-2 border-red-400 text-red-300"
-                            >
-                                Dismiss
-                            </Button>
-                        </div>
-                    )}
-                </div>
-
-                {/* Loading Deck State */}
-                {loadingDeck && (
-                    <div className="mb-6 p-4 bg-purple-900/50 border border-purple-500 rounded-lg">
-                        <div className="flex items-center">
-                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-purple-400 mr-3"></div>
-                            <span className="text-purple-300">Loading deck...</span>
-                        </div>
-                    </div>
-                )}
-
-                {/* Main Content Grid */}
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                    {/* Left Column: Card Browser and Stage Selection */}
-                    <div className="lg:col-span-2 space-y-6">
-                        {/* Card Browser */}
-                        <Card className="bg-gray-900 border-gray-800">
-                            <CardHeader className="border-b border-gray-800 p-4">
-                                <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
-                                    <CardTitle className="text-xl">{stageInfo.title}</CardTitle>
-
-                                    {/* Search + Filter toggle */}
-                                    <div className="flex gap-2 w-full sm:w-auto">
-                                        <input
-                                            type="text"
-                                            placeholder="Search cards..."
-                                            className="flex-1 sm:w-52 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent text-sm"
-                                            onChange={(e) => debouncedSearch(e.target.value)}
-                                        />
-                                        {currentStage === 'cards' && (
-                                            <button
-                                                onClick={() => setShowFilters(f => !f)}
-                                                className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${showFilters ? 'bg-purple-600 border-purple-500 text-white' : 'bg-gray-800 border-gray-700 text-gray-300 hover:bg-gray-700'}`}
-                                            >
-                                                Filters {(filterAspects.length + filterKeywords.length + filterTraits.length + filterSets.length) > 0 ? `(${filterAspects.length + filterKeywords.length + filterTraits.length + filterSets.length})` : ''}
-                                            </button>
-                                        )}
-                                    </div>
-                                </div>
-
-                                {/* Expanded filter panel — cards stage only */}
-                                {currentStage === 'cards' && showFilters && (
-                                    <div className="mt-4 pt-4 border-t border-gray-700 grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        {/* Sort */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Sort by</label>
-                                            <select
-                                                value={sortBy}
-                                                onChange={e => setSortBy(e.target.value)}
-                                                className="w-full px-2 py-1.5 bg-gray-800 border border-gray-700 rounded text-white text-sm"
-                                            >
-                                                <option value="name_asc">Name (A–Z)</option>
-                                                <option value="name_desc">Name (Z–A)</option>
-                                                <option value="cost_asc">Cost (Low → High)</option>
-                                                <option value="cost_desc">Cost (High → Low)</option>
-                                                <option value="type_asc">Type</option>
-                                                <option value="set_newest">Set (Newest)</option>
-                                                <option value="set_oldest">Set (Oldest)</option>
-                                                <option value="rarity_rare">Rarity (Rare → Common)</option>
-                                                <option value="rarity_common">Rarity (Common → Rare)</option>
-                                            </select>
-                                        </div>
-
-                                        {/* Type filter (kept as a quick select) */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Card type</label>
-                                            <select
-                                                value={cardTypeFilter}
-                                                onChange={(e) => setCardTypeFilter(e.target.value)}
-                                                className="w-full px-2 py-1.5 bg-gray-800 border border-gray-700 rounded text-white text-sm"
-                                            >
-                                                <option value="">All types</option>
-                                                <option value="Unit">Unit</option>
-                                                <option value="Event">Event</option>
-                                                <option value="Upgrade">Upgrade</option>
-                                            </select>
-                                        </div>
-
-                                        {/* Set */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Set</label>
-                                            <div className="max-h-28 overflow-y-auto space-y-1 pr-1">
-                                                {availableSets.map(s => (
-                                                    <label key={s} className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer hover:text-white">
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={filterSets.includes(s)}
-                                                            onChange={e => setFilterSets(prev => e.target.checked ? [...prev, s] : prev.filter(x => x !== s))}
-                                                            className="accent-purple-500"
-                                                        />
-                                                        {s}
-                                                    </label>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Aspects */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Aspect</label>
-                                            <div className="flex flex-wrap gap-1">
-                                                {availableAspects.map(a => (
-                                                    <button
-                                                        key={a}
-                                                        onClick={() => setFilterAspects(prev => prev.includes(a) ? prev.filter(x => x !== a) : [...prev, a])}
-                                                        className={`px-2 py-0.5 rounded text-xs font-medium border transition-colors ${filterAspects.includes(a) ? 'bg-purple-600 border-purple-500 text-white' : 'bg-gray-800 border-gray-600 text-gray-300 hover:border-gray-400'}`}
-                                                    >
-                                                        {a}
-                                                    </button>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Keywords */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Keyword</label>
-                                            <div className="max-h-28 overflow-y-auto space-y-1 pr-1">
-                                                {availableKeywords.map(k => (
-                                                    <label key={k} className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer hover:text-white">
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={filterKeywords.includes(k)}
-                                                            onChange={e => setFilterKeywords(prev => e.target.checked ? [...prev, k] : prev.filter(x => x !== k))}
-                                                            className="accent-purple-500"
-                                                        />
-                                                        {k}
-                                                    </label>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Traits */}
-                                        <div>
-                                            <label className="block text-xs text-gray-400 mb-1">Trait</label>
-                                            <div className="max-h-28 overflow-y-auto space-y-1 pr-1">
-                                                {availableTraits.map(t => (
-                                                    <label key={t} className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer hover:text-white">
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={filterTraits.includes(t)}
-                                                            onChange={e => setFilterTraits(prev => e.target.checked ? [...prev, t] : prev.filter(x => x !== t))}
-                                                            className="accent-purple-500"
-                                                        />
-                                                        {t}
-                                                    </label>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Clear filters */}
-                                        {(filterAspects.length + filterKeywords.length + filterTraits.length + filterSets.length) > 0 && (
-                                            <div className="sm:col-span-2">
-                                                <button
-                                                    onClick={() => { setFilterAspects([]); setFilterKeywords([]); setFilterTraits([]); setFilterSets([]); setSortBy('name_asc'); }}
-                                                    className="text-xs text-red-400 hover:text-red-300 underline"
-                                                >
-                                                    Clear all filters
-                                                </button>
-                                            </div>
-                                        )}
-                                    </div>
-                                )}
-
-                                {/* Stage Controls */}
-                                {currentStage === 'cards' && (
-                                    <div className="flex flex-wrap gap-4 items-center mt-4">
-                                        <div className="flex items-center space-x-2">
-                                            <Switch
-                                                id="show-all-cards"
-                                                checked={showAllCards}
-                                                onCheckedChange={setShowAllCards}
-                                            />
-                                            <Label htmlFor="show-all-cards" className="text-sm text-gray-300">
-                                                Show all cards (ignore aspects)
-                                            </Label>
-                                        </div>
-                                        <div className="flex items-center space-x-2">
-                                            <Switch
-                                                id="hide-cards-in-deck"
-                                                checked={hideCardsInDeck}
-                                                onCheckedChange={setHideCardsInDeck}
-                                            />
-                                            <Label htmlFor="hide-cards-in-deck" className="text-sm text-gray-300">
-                                                Hide cards already in deck
-                                            </Label>
-                                        </div>
-                                    </div>
-                                )}
-                            </CardHeader>
-                            
-                            <CardContent className="p-0">
-                                {loading ? (
-                                    <div className="h-96 flex items-center justify-center text-purple-400">
-                                        Loading available cards...
-                                    </div>
-                                ) : displayedCards.length === 0 && !loading ? (
-                                    <div className="h-96 flex items-center justify-center text-gray-400 p-4 text-center">
-                                        {searchQuery ? 
-                                            `No cards found matching "${searchQuery}".` : 
-                                            `No ${currentStage === 'leaders' ? 'leaders' : currentStage === 'base' ? 'bases' : 'cards'} available for this stage.`
-                                        }
-                                    </div>
-                                ) : (
-                                    <div className="max-h-[60vh] overflow-y-auto p-4">
-                                        <CardGrid
-                                            key={`card-grid-${currentStage}-${searchQuery}-${cardTypeFilter}-${showAllCards}-${hideCardsInDeck}-${filterAspects.join(',')}-${filterKeywords.join(',')}-${filterTraits.join(',')}-${filterSets.join(',')}-${sortBy}`}
-                                            cards={displayedCards}
-                                            onCardClickAction={handleCardClick}
-                                            onDoubleClickAction={handleCardDoubleClick}
-                                            isInDeck={isCardIdInDeck}
-                                        />
-                                        {hasMoreCards && displayedCards.length > 0 && (
-                                            <div ref={lastCardElementRef} style={{ height: '10px', background: 'transparent' }} />
-                                        )}
-                                    </div>
-                                )}
-                                
-                                {hasMoreCards && !loading && displayedCards.length > 0 && (
-                                    <div className="p-4 flex justify-center border-t border-gray-800">
-                                        <Button 
-                                            onClick={loadMoreCardsHandler} 
-                                            variant="outline" 
-                                            disabled={isLoadingMore} 
-                                            className="bg-gray-800 hover:bg-gray-700 text-white"
-                                        >
-                                            {isLoadingMore ? (
-                                                <>
-                                                    <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
-                                                    Loading...
-                                                </>
-                                            ) : (
-                                                'Load More'
-                                            )}
-                                        </Button>
-                                    </div>
-                                )}
-                                
-                                {!loading && !hasMoreCards && cards.length > 0 && (
-                                    <div className="p-4 text-center text-gray-500 text-sm border-t border-gray-800">
-                                        End of results.
-                                    </div>
-                                )}
-                            </CardContent>
-                        </Card>
-
-                        {/* Stage-specific Selection Areas */}
-                        {currentStage === 'leaders' && renderLeaderSelectionArea()}
-                        {currentStage === 'base' && renderBaseSelectionArea()}
-                        {currentStage === 'cards' && renderCardsSelectionArea()}
-                    </div>
-
-                    {/* Right Column: Card Detail */}
-                    <div className="lg:col-span-1">
-                        <Card className="bg-gray-900 border-gray-800 h-full sticky top-24">
-                            <CardHeader className="border-b border-gray-800 p-4">
-                                <CardTitle className="text-xl">Card Details</CardTitle>
-                            </CardHeader>
-                            <CardContent className="p-0 max-h-[calc(100vh-10rem)] overflow-y-auto">
-                                {selectedCard ? (
-                                    <MemoizedCardDetail 
-                                        key={selectedCard.id} 
-                                        card={selectedCard} 
-                                        onAddToDeck={handleAddToDeck} 
-                                        onRemoveFromDeck={handleRemoveFromDeck} 
-                                        isInDeck={isCardIdInDeck(selectedCard.id)} 
-                                        isCompatible={currentStage === 'cards' ? isCardInAspect(selectedCard) : true}
-                                        currentStage={currentStage}
-                                    />
-                                ) : (
-                                    <div className="p-6 text-center text-gray-400">
-                                        <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
-                                            <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                            </svg>
-                                        </div>
-                                        <h3 className="text-lg font-medium mb-2">No Card Selected</h3>
-                                        <p>Click on a card to view its details</p>
-                                    </div>
-                                )}
-                            </CardContent>
-                        </Card>
-                    </div>
-                </div>
-            </div>
-
-            {/* Save Deck Dialog */}
-            <SaveDeckDialog
-                isOpen={showSaveDialog}
-                onClose={() => setShowSaveDialog(false)}
-                existingDeckId={deckIdParam || undefined}
-                onSuccess={(deckId) => {
-                    setShowSaveDialog(false);
-                    router.push(`/profile`);
-                }}
+  return (
+    <div>
+      <div
+        className="ts-eyebrow"
+        style={{ marginBottom: 12, paddingLeft: 0 }}
+      >
+        Resource Curve
+      </div>
+      <div className="ts-curve-chart" style={{ marginBottom: 28 }}>
+        {curve.map((n, i) => (
+          <div key={i} className="ts-curve-bar">
+            <div
+              className="ts-curve-bar-fill"
+              style={{ height: `${(n / maxBar) * 100}%` }}
             />
-        </div>
+            {n > 0 && (
+              <span
+                style={{
+                  position: 'absolute',
+                  top: -16,
+                  left: 0,
+                  right: 0,
+                  textAlign: 'center',
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 10,
+                  color: 'var(--ts-ink)',
+                }}
+              >
+                {n}
+              </span>
+            )}
+            <span
+              style={{
+                position: 'absolute',
+                bottom: -18,
+                left: 0,
+                right: 0,
+                textAlign: 'center',
+                fontFamily: 'var(--ts-font-mono)',
+                fontSize: 9,
+                color: 'var(--ts-ink-3)',
+              }}
+            >
+              {labels[i]}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Composition bar ────────────────────────────────────────
+function CompositionBar({ deckCards }: { deckCards: { card: CardType; quantity: number }[] }) {
+  const counts = { Unit: 0, Event: 0, Upgrade: 0, Other: 0 };
+  deckCards.forEach(({ card, quantity }) => {
+    const t = card.type ?? '';
+    if (t.toLowerCase().includes('unit'))    counts.Unit    += quantity;
+    else if (t.toLowerCase().includes('event'))   counts.Event   += quantity;
+    else if (t.toLowerCase().includes('upgrade')) counts.Upgrade += quantity;
+    else counts.Other += quantity;
+  });
+  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1;
+
+  const segments = [
+    { key: 'Unit',    color: 'var(--ts-amber)',  n: counts.Unit },
+    { key: 'Event',   color: 'var(--ts-blue)',   n: counts.Event },
+    { key: 'Upgrade', color: 'var(--ts-green)',  n: counts.Upgrade },
+  ].filter(s => s.n > 0);
+
+  if (segments.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Composition</div>
+      <div style={{ height: 7, display: 'flex', border: '1px solid var(--ts-line-2)' }}>
+        {segments.map(s => (
+          <div
+            key={s.key}
+            style={{ width: `${(s.n / total) * 100}%`, background: s.color }}
+            title={`${s.key}: ${s.n}`}
+          />
+        ))}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginTop: 7,
+          fontFamily: 'var(--ts-font-mono)',
+          fontSize: 10,
+          color: 'var(--ts-ink-2)',
+        }}
+      >
+        {segments.map(s => (
+          <span key={s.key}>
+            <span style={{ display:'inline-block', width:7, height:7, background:s.color, marginRight:5 }} />
+            {s.key} {s.n}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Deck panel (right column) ──────────────────────────────
+function DeckPanel({
+  deckCards, leaders, base, deckName, setDeckName,
+  addCard, removeCard,
+  openHandSim, openMulligan,
+  onSave, totalCards,
+}: {
+  deckCards: { card: CardType; quantity: number }[];
+  leaders: CardType[];
+  base: CardType | null;
+  deckName: string;
+  setDeckName: (n: string) => void;
+  addCard: (c: CardType) => void;
+  removeCard: (id: string) => void;
+  openHandSim: () => void;
+  openMulligan: () => void;
+  onSave: () => void;
+  totalCards: number;
+}) {
+  const grouped = useMemo(() => {
+    const g: Record<string, { card: CardType; quantity: number }[]> = {
+      Unit: [], Event: [], Upgrade: [], Other: [],
+    };
+    deckCards.forEach(item => {
+      const t = item.card.type ?? '';
+      if (t.toLowerCase().includes('unit'))         g.Unit.push(item);
+      else if (t.toLowerCase().includes('event'))   g.Event.push(item);
+      else if (t.toLowerCase().includes('upgrade')) g.Upgrade.push(item);
+      else g.Other.push(item);
+    });
+    Object.values(g).forEach(arr =>
+      arr.sort((a, b) => {
+        const ca = a.card.cost ?? a.card.energy_cost ?? 0;
+        const cb = b.card.cost ?? b.card.energy_cost ?? 0;
+        return ca - cb || a.card.name.localeCompare(b.card.name);
+      })
     );
+    return g;
+  }, [deckCards]);
+
+  const avgCost = useMemo(() => {
+    const sum = deckCards.reduce((s, { card, quantity }) => s + (card.cost ?? card.energy_cost ?? 0) * quantity, 0);
+    return totalCards > 0 ? (sum / totalCards).toFixed(1) : '—';
+  }, [deckCards, totalCards]);
+
+  const leaderAspects = leaders.flatMap(l => l.aspects?.map(a => a.aspect_name) ?? []);
+
+  const sections = [
+    ['Units', grouped.Unit],
+    ['Events', grouped.Event],
+    ['Upgrades', grouped.Upgrade],
+    ['Other', grouped.Other],
+  ] as [string, { card: CardType; quantity: number }[]][];
+
+  const isTargetMet = totalCards >= 30;
+
+  return (
+    <div>
+      {/* Header */}
+      <div style={{ paddingBottom: 14, borderBottom: '1px solid var(--ts-line)' }}>
+        <div className="ts-eyebrow" style={{ marginBottom: 6 }}>Working Deck</div>
+        <input
+          value={deckName}
+          onChange={e => setDeckName(e.target.value)}
+          style={{
+            fontFamily: 'var(--ts-font-display)',
+            fontSize: 22,
+            color: 'var(--ts-ink)',
+            background: 'transparent',
+            border: 'none',
+            outline: 'none',
+            width: '100%',
+            padding: '2px 0',
+          }}
+        />
+        {leaderAspects.length > 0 && (
+          <div style={{ display: 'flex', gap: 5, marginTop: 6, flexWrap: 'wrap' }}>
+            {leaderAspects.map((a, i) => <AspectPip key={i} aspect={a} />)}
+            {leaders[0] && (
+              <span
+                style={{
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 10,
+                  color: 'var(--ts-ink-3)',
+                  letterSpacing: '0.12em',
+                  alignSelf: 'center',
+                }}
+              >
+                {leaders.map(l => l.name).join(' · ').toUpperCase()}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Stats row */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          borderBottom: '1px solid var(--ts-line)',
+        }}
+      >
+        {[
+          { l: 'Cards', v: totalCards, sub: '/ 30 min' },
+          { l: 'Avg Cost', v: avgCost },
+          { l: 'Stage', v: leaders.length === 2 && base ? 'Ready' : 'Setup', sub: leaders.length < 2 ? `${leaders.length}/2 leaders` : !base ? 'no base' : undefined },
+        ].map(s => (
+          <div key={s.l} style={{ padding: '12px 10px', borderRight: '1px solid var(--ts-line)' }}>
+            <div className="ts-eyebrow" style={{ marginBottom: 4 }}>{s.l}</div>
+            <div
+              style={{
+                fontFamily: 'var(--ts-font-display)',
+                fontSize: 22,
+                lineHeight: 1,
+                color: s.l === 'Cards' && isTargetMet ? 'var(--ts-green)' : 'var(--ts-ink)',
+              }}
+            >
+              {s.v}
+            </div>
+            {s.sub && (
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 9,
+                  color: 'var(--ts-ink-4)',
+                  marginTop: 2,
+                }}
+              >
+                {s.sub}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Curve + composition */}
+      <div style={{ padding: '20px 6px 6px' }}>
+        <ResourceCurveChart deckCards={deckCards} />
+        <CompositionBar deckCards={deckCards} />
+      </div>
+
+      {/* Sim buttons */}
+      {totalCards > 0 && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 14, padding: '0 2px' }}>
+          <button className="ts-btn ts-btn-sm ts-btn-blue" onClick={openHandSim}>◇ Hand Sim</button>
+          <button className="ts-btn ts-btn-sm ts-btn-blue" onClick={openMulligan}>◇ Mulligan</button>
+        </div>
+      )}
+
+      {/* Deck list */}
+      <div style={{ borderTop: '1px solid var(--ts-line)' }}>
+        {sections.map(([label, list]) =>
+          list.length > 0 ? (
+            <div key={label} style={{ paddingBottom: 4 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  padding: '10px 8px 5px',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'var(--ts-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: '0.2em',
+                    color: 'var(--ts-amber)',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {label}
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--ts-font-mono)',
+                    fontSize: 9,
+                    color: 'var(--ts-ink-3)',
+                  }}
+                >
+                  {list.reduce((s, i) => s + i.quantity, 0)}
+                </span>
+              </div>
+              {list.map(({ card, quantity }) => (
+                <div key={card.id} className="ts-deck-row">
+                  <span
+                    style={{
+                      fontFamily: 'var(--ts-font-mono)',
+                      fontSize: 10,
+                      color: 'var(--ts-amber)',
+                    }}
+                  >
+                    ×{quantity}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--ts-font-mono)',
+                      fontSize: 10,
+                      color: 'var(--ts-ink-3)',
+                    }}
+                  >
+                    {card.cost ?? card.energy_cost ?? '—'}
+                  </span>
+                  <span style={{ fontSize: 13, color: 'var(--ts-ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {card.name}
+                  </span>
+                  <button
+                    onClick={() => removeCard(card.id)}
+                    style={{
+                      background: 'transparent',
+                      border: '1px solid var(--ts-line-2)',
+                      color: 'var(--ts-ink-3)',
+                      width: 20,
+                      height: 20,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      cursor: 'pointer',
+                      fontFamily: 'var(--ts-font-mono)',
+                      fontSize: 12,
+                      padding: 0,
+                      flexShrink: 0,
+                    }}
+                    onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ts-red)'; (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--ts-red)'; }}
+                    onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ts-ink-3)'; (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--ts-line-2)'; }}
+                  >
+                    −
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null
+        )}
+      </div>
+
+      {/* Footer actions */}
+      <div style={{ padding: '14px 2px 0', display: 'flex', flexDirection: 'column', gap: 7 }}>
+        <button
+          className="ts-btn ts-btn-primary ts-btn-sm"
+          style={{ width: '100%', justifyContent: 'center' }}
+          onClick={onSave}
+          disabled={leaders.length !== 2 || !base}
+        >
+          Save Deck
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Stage banner (leaders/base setup) ─────────────────────
+function StageBanner({
+  currentStage, leaders, base, resetDeck, setStage,
+  handleRemoveFromDeck,
+}: {
+  currentStage: string;
+  leaders: CardType[];
+  base: CardType | null;
+  resetDeck: () => void;
+  setStage: (s: 'leaders' | 'base' | 'cards') => void;
+  handleRemoveFromDeck: (id: string) => void;
+}) {
+  if (currentStage === 'cards') return null;
+
+  const isLeaders = currentStage === 'leaders';
+
+  return (
+    <div
+      style={{
+        background: 'var(--ts-panel)',
+        border: '1px solid var(--ts-line)',
+        padding: 20,
+        marginBottom: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          marginBottom: 16,
+        }}
+      >
+        <div>
+          <div className="ts-eyebrow" style={{ marginBottom: 4 }}>
+            {isLeaders ? `Step 1 · Select Leaders` : `Step 2 · Select Base`}
+          </div>
+          <div
+            style={{ fontFamily: 'var(--ts-font-display)', fontSize: 20, color: 'var(--ts-ink)' }}
+          >
+            {isLeaders
+              ? `Choose two leaders (${leaders.length}/2)`
+              : 'Choose your base'}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {!isLeaders && (
+            <button
+              className="ts-btn ts-btn-sm"
+              onClick={() => setStage('leaders')}
+            >
+              ← Leaders
+            </button>
+          )}
+          <button
+            className="ts-btn ts-btn-sm"
+            onClick={resetDeck}
+            style={{ color: 'var(--ts-red)', borderColor: 'var(--ts-red)' }}
+          >
+            Reset
+          </button>
+          {isLeaders && leaders.length === 2 && (
+            <button
+              className="ts-btn ts-btn-sm ts-btn-primary"
+              onClick={() => setStage('base')}
+            >
+              Next: Base →
+            </button>
+          )}
+          {!isLeaders && base && (
+            <button
+              className="ts-btn ts-btn-sm ts-btn-primary"
+              onClick={() => setStage('cards')}
+            >
+              Build Deck →
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        {isLeaders
+          ? leaders.map(leader => (
+              <div
+                key={leader.id}
+                style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 10 }}
+              >
+                <div
+                  style={{
+                    width: 44,
+                    height: 44,
+                    overflow: 'hidden',
+                    border: '1px solid var(--ts-amber)',
+                    flexShrink: 0,
+                  }}
+                >
+                  <img
+                    src={leader.image_uri ?? '/placeholder-card.png'}
+                    alt={leader.name}
+                    style={{ width: '100%', height: '100%', objectFit: 'cover', objectPosition: '50% 20%' }}
+                    onError={e => { (e.target as HTMLImageElement).src = '/placeholder-card.png'; }}
+                  />
+                </div>
+                <div>
+                  <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 15, color: 'var(--ts-ink)' }}>{leader.name}</div>
+                  <div style={{ display: 'flex', gap: 4, marginTop: 3 }}>
+                    {leader.aspects?.map(a => <AspectPip key={a.aspect_name} aspect={a.aspect_name} />)}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleRemoveFromDeck(leader.id)}
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid var(--ts-line-2)',
+                    color: 'var(--ts-ink-3)',
+                    width: 18,
+                    height: 18,
+                    cursor: 'pointer',
+                    fontSize: 10,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 0,
+                    alignSelf: 'flex-start',
+                  }}
+                >
+                  ✕
+                </button>
+              </div>
+            ))
+          : base ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div
+                style={{
+                  width: 44,
+                  height: 44,
+                  overflow: 'hidden',
+                  border: '1px solid var(--ts-amber)',
+                }}
+              >
+                <img
+                  src={base.image_uri ?? '/placeholder-card.png'}
+                  alt={base.name}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover', objectPosition: '50% 20%' }}
+                  onError={e => { (e.target as HTMLImageElement).src = '/placeholder-card.png'; }}
+                />
+              </div>
+              <div>
+                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 15, color: 'var(--ts-ink)' }}>{base.name}</div>
+                <div style={{ display: 'flex', gap: 4, marginTop: 3 }}>
+                  {base.aspects?.map(a => <AspectPip key={a.aspect_name} aspect={a.aspect_name} />)}
+                </div>
+              </div>
+              <button
+                onClick={() => handleRemoveFromDeck(base.id)}
+                style={{
+                  background: 'transparent',
+                  border: '1px solid var(--ts-line-2)',
+                  color: 'var(--ts-ink-3)',
+                  width: 18,
+                  height: 18,
+                  cursor: 'pointer',
+                  fontSize: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 0,
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ── Filter sidebar ──────────────────────────────────────────
+function FilterSidebar({
+  filterAspects, setFilterAspects,
+  filterTraits, setFilterTraits,
+  filterSets, setFilterSets,
+  cardTypeFilter, setCardTypeFilter,
+  availableAspects, availableTraits, availableSets,
+  showAllCards, setShowAllCards,
+  hideCardsInDeck, setHideCardsInDeck,
+  currentStage,
+}: {
+  filterAspects: string[];
+  setFilterAspects: React.Dispatch<React.SetStateAction<string[]>>;
+  filterTraits: string[];
+  setFilterTraits: React.Dispatch<React.SetStateAction<string[]>>;
+  filterSets: string[];
+  setFilterSets: React.Dispatch<React.SetStateAction<string[]>>;
+  cardTypeFilter: string;
+  setCardTypeFilter: React.Dispatch<React.SetStateAction<string>>;
+  availableAspects: string[];
+  availableTraits: string[];
+  availableSets: string[];
+  showAllCards: boolean;
+  setShowAllCards: React.Dispatch<React.SetStateAction<boolean>>;
+  hideCardsInDeck: boolean;
+  setHideCardsInDeck: React.Dispatch<React.SetStateAction<boolean>>;
+  currentStage: string;
+}) {
+  const toggle = (arr: string[], val: string, set: React.Dispatch<React.SetStateAction<string[]>>) => {
+    set(arr.includes(val) ? arr.filter(v => v !== val) : [...arr, val]);
+  };
+
+  const ASPECTS = ['Command', 'Aggression', 'Cunning', 'Heroism', 'Vigilance', 'Villainy'];
+  const TYPES = ['Unit', 'Event', 'Upgrade'];
+
+  if (currentStage !== 'cards') return null;
+
+  return (
+    <aside
+      style={{
+        borderRight: '1px solid var(--ts-line)',
+        background: 'var(--ts-panel)',
+        padding: '18px 16px',
+        overflowY: 'auto',
+        height: '100%',
+      }}
+    >
+      {/* Aspect */}
+      <div style={{ borderBottom: '1px solid var(--ts-line)', paddingBottom: 16, marginBottom: 0 }}>
+        <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Aspect</div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 5 }}>
+          {ASPECTS.map(a => (
+            <button
+              key={a}
+              className={'ts-filter-pill' + (filterAspects.includes(a) ? ' is-active' : '')}
+              onClick={() => toggle(filterAspects, a, setFilterAspects)}
+              style={{ justifyContent: 'flex-start', gap: 5 }}
+            >
+              <AspectPip aspect={a} />
+              <span style={{ fontSize: 9, letterSpacing: '0.1em' }}>{a.toUpperCase()}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Card Type */}
+      <div style={{ borderBottom: '1px solid var(--ts-line)', padding: '14px 0' }}>
+        <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Card Type</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+          {TYPES.map(t => (
+            <button
+              key={t}
+              className={'ts-filter-pill' + (cardTypeFilter === t ? ' is-active' : '')}
+              onClick={() => setCardTypeFilter(prev => prev === t ? '' : t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Set */}
+      {availableSets.length > 0 && (
+        <div style={{ borderBottom: '1px solid var(--ts-line)', padding: '14px 0' }}>
+          <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Set</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {availableSets.slice(0, 8).map(s => (
+              <label
+                key={s}
+                style={{
+                  display: 'flex',
+                  gap: 8,
+                  alignItems: 'center',
+                  fontSize: 11,
+                  color: 'var(--ts-ink-2)',
+                  cursor: 'pointer',
+                  fontFamily: 'var(--ts-font-mono)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={filterSets.includes(s)}
+                  onChange={e =>
+                    setFilterSets(prev =>
+                      e.target.checked ? [...prev, s] : prev.filter(x => x !== s)
+                    )
+                  }
+                  style={{ accentColor: 'var(--ts-amber)' }}
+                />
+                {s}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Traits */}
+      {availableTraits.length > 0 && (
+        <div style={{ borderBottom: '1px solid var(--ts-line)', padding: '14px 0' }}>
+          <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Trait</div>
+          <div style={{ maxHeight: 180, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {availableTraits.slice(0, 20).map(t => (
+              <label
+                key={t}
+                style={{
+                  display: 'flex',
+                  gap: 8,
+                  alignItems: 'center',
+                  fontSize: 11,
+                  color: 'var(--ts-ink-2)',
+                  cursor: 'pointer',
+                  fontFamily: 'var(--ts-font-mono)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={filterTraits.includes(t)}
+                  onChange={e =>
+                    setFilterTraits(prev =>
+                      e.target.checked ? [...prev, t] : prev.filter(x => x !== t)
+                    )
+                  }
+                  style={{ accentColor: 'var(--ts-amber)' }}
+                />
+                {t}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Smart filters */}
+      <div style={{ padding: '14px 0' }}>
+        <div className="ts-eyebrow" style={{ marginBottom: 10 }}>Smart Filters</div>
+        <label
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+            fontSize: 12,
+            color: 'var(--ts-ink-2)',
+            cursor: 'pointer',
+            marginBottom: 10,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={hideCardsInDeck}
+            onChange={e => setHideCardsInDeck(e.target.checked)}
+            style={{ accentColor: 'var(--ts-amber)' }}
+          />
+          Hide cards in deck
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+            fontSize: 12,
+            color: 'var(--ts-ink-2)',
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showAllCards}
+            onChange={e => setShowAllCards(e.target.checked)}
+            style={{ accentColor: 'var(--ts-amber)' }}
+          />
+          Show all aspects
+        </label>
+      </div>
+
+      {/* Clear */}
+      {(filterAspects.length + filterTraits.length + filterSets.length) > 0 && (
+        <button
+          onClick={() => { setFilterAspects([]); setFilterTraits([]); setFilterSets([]); setCardTypeFilter(''); }}
+          style={{
+            fontFamily: 'var(--ts-font-mono)',
+            fontSize: 9,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: 'var(--ts-red)',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px 0',
+          }}
+        >
+          Clear All Filters
+        </button>
+      )}
+    </aside>
+  );
+}
+
+// ── Card list (middle column) ──────────────────────────────
+function CardListView({
+  cards, deck, addCard, removeCard,
+  loading, hasMoreCards, isLoadingMore, loadMore,
+  isCardInDeck,
+}: {
+  cards: CardType[];
+  deck: { cards: { card: CardType; quantity: number }[] };
+  addCard: (c: CardType) => void;
+  removeCard: (id: string) => void;
+  loading: boolean;
+  hasMoreCards: boolean;
+  isLoadingMore: boolean;
+  loadMore: () => void;
+  isCardInDeck: (id: string) => boolean;
+}) {
+  if (loading) {
+    return (
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--ts-ink-3)',
+          fontFamily: 'var(--ts-font-mono)',
+          fontSize: 11,
+          letterSpacing: '0.16em',
+        }}
+      >
+        Loading cards…
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* Column headers */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '28px 1fr auto 88px',
+          gap: 8,
+          padding: '8px 12px',
+          background: 'var(--ts-bg-2)',
+          borderBottom: '1px solid var(--ts-line)',
+          fontFamily: 'var(--ts-font-mono)',
+          fontSize: 9,
+          letterSpacing: '0.2em',
+          textTransform: 'uppercase',
+          color: 'var(--ts-ink-3)',
+          flexShrink: 0,
+        }}
+      >
+        <span>#</span>
+        <span>Card · Type</span>
+        <span>Aspects</span>
+        <span style={{ textAlign: 'right' }}>Action</span>
+      </div>
+
+      {/* Card rows */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {cards.length === 0 ? (
+          <div
+            style={{
+              padding: 40,
+              textAlign: 'center',
+              color: 'var(--ts-ink-3)',
+              fontFamily: 'var(--ts-font-mono)',
+              fontSize: 11,
+              letterSpacing: '0.14em',
+            }}
+          >
+            No cards found
+          </div>
+        ) : (
+          cards.map(card => {
+            const inDeck = isCardInDeck(card.id);
+            const cost = card.cost ?? card.energy_cost ?? '—';
+            return (
+              <div key={card.id} className="ts-card-row">
+                <span
+                  style={{
+                    fontFamily: 'var(--ts-font-mono)',
+                    fontSize: 12,
+                    color: 'var(--ts-ink)',
+                    fontWeight: 600,
+                  }}
+                >
+                  {cost}
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontFamily: 'var(--ts-font-display)',
+                      fontSize: 14,
+                      color: 'var(--ts-ink)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {card.name}
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--ts-font-mono)',
+                      fontSize: 9,
+                      color: 'var(--ts-ink-3)',
+                      letterSpacing: '0.14em',
+                      marginTop: 1,
+                    }}
+                  >
+                    {card.type}
+                    {card.power !== undefined && card.hp !== undefined
+                      ? ` · ${card.power}/${card.hp}`
+                      : ''}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: 3 }}>
+                  {card.aspects?.map(a => (
+                    <AspectPip key={a.aspect_name} aspect={a.aspect_name} />
+                  ))}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  {inDeck ? (
+                    <button
+                      className="ts-filter-pill is-active"
+                      style={{
+                        padding: '4px 10px',
+                        background: 'var(--ts-green)',
+                        borderColor: 'var(--ts-green)',
+                        color: '#0e1410',
+                        fontSize: 9,
+                      }}
+                      onClick={() => removeCard(card.id)}
+                    >
+                      ✓ IN DECK
+                    </button>
+                  ) : (
+                    <button
+                      className="ts-filter-pill"
+                      style={{ padding: '4px 10px', fontSize: 9 }}
+                      onClick={() => addCard(card)}
+                    >
+                      + ADD
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+
+        {hasMoreCards && !isLoadingMore && cards.length > 0 && (
+          <div style={{ padding: 16, textAlign: 'center' }}>
+            <button
+              className="ts-btn ts-btn-sm"
+              onClick={loadMore}
+            >
+              Load More
+            </button>
+          </div>
+        )}
+        {isLoadingMore && (
+          <div
+            style={{
+              padding: 16,
+              textAlign: 'center',
+              fontFamily: 'var(--ts-font-mono)',
+              fontSize: 10,
+              color: 'var(--ts-ink-3)',
+            }}
+          >
+            Loading…
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────
+export default function DeckBuilderClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const deckIdParam = searchParams.get('deckId');
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.push('/login?redirect=/deck-builder');
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  // State
+  const [isPotentialLoop, setIsPotentialLoop] = useState(false);
+  const [cards, setCards] = useState<CardType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadingDeck, setLoadingDeck] = useState(!!deckIdParam);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [cardTypeFilter, setCardTypeFilter] = useState('');
+  const [showAllCards, setShowAllCards] = useState(false);
+  const [hideCardsInDeck, setHideCardsInDeck] = useState(true);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasMoreCards, setHasMoreCards] = useState(true);
+  const [handSimMode, setHandSimMode] = useState<'sim' | 'mulligan' | null>(null);
+
+  // Filter state
+  const [filterAspects, setFilterAspects] = useState<string[]>([]);
+  const [filterTraits, setFilterTraits] = useState<string[]>([]);
+  const [filterSets, setFilterSets] = useState<string[]>([]);
+  const [availableAspects, setAvailableAspects] = useState<string[]>([]);
+  const [availableTraits, setAvailableTraits] = useState<string[]>([]);
+  const [availableSets, setAvailableSets] = useState<string[]>([]);
+
+  const loadingRef = useRef(false);
+  const cardLoadingStageRef = useRef<string | null>(null);
+
+  // Context
+  const {
+    currentStage, leaders, base, deckCards, deckName,
+    addLeader, removeLeader, setBase: setBaseContext, addCard, removeCard,
+    setDeckName, isCardInDeck: isCardIdInDeck, isCardInAspect, resetDeck,
+    setCurrentStage: contextSetCurrentStage, totalCards,
+  } = useDeckBuilder();
+
+  // Loop detection
+  useEffect(() => {
+    const visitTimestamp = Date.now();
+    let visitHistory: number[] = [];
+    try { visitHistory = JSON.parse(sessionStorage.getItem('deckBuilderVisitHistory') || '[]'); }
+    catch { visitHistory = []; }
+    const recentVisits = visitHistory.filter(ts => visitTimestamp - ts < LOOP_CHECK_WINDOW_MS);
+    recentVisits.push(visitTimestamp);
+    sessionStorage.setItem('deckBuilderVisitHistory', JSON.stringify(recentVisits));
+    if (recentVisits.length > MAX_VISITS_IN_WINDOW) {
+      setIsPotentialLoop(true);
+      sessionStorage.clear();
+    }
+    const timer = setTimeout(() => sessionStorage.removeItem('deckBuilderVisitHistory'), LOOP_CHECK_WINDOW_MS + 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Load filter options
+  useEffect(() => {
+    if (currentStage !== 'cards' || availableAspects.length > 0) return;
+    Promise.all([fetchAspects(), fetchSets(), fetchTraits()])
+      .then(([asp, sets, traits]) => {
+        setAvailableAspects(asp.map((a: any) => a.aspect_name).filter(Boolean));
+        setAvailableSets(sets.map((s: any) => s.set_name).filter(Boolean));
+        setAvailableTraits(traits.map((t: any) => t.trait).filter(Boolean));
+      })
+      .catch(err => console.error('[DeckBuilder] filter options:', err));
+  }, [currentStage, availableAspects.length]);
+
+  // Load cards
+  const loadCards = useCallback(async (page = 1, append = false) => {
+    if (loadingRef.current || (append && !hasMoreCards)) return;
+    loadingRef.current = true;
+    if (page === 1 && !append) setLoading(true);
+    else if (append) setIsLoadingMore(true);
+
+    const params: FetchCardsParams = {
+      page: page.toString(),
+      limit: CARDS_PER_PAGE.toString(),
+      search: searchQuery || undefined,
+    };
+
+    if (currentStage === 'leaders') params.type = 'Leader';
+    else if (currentStage === 'base') params.type = 'Base';
+    else {
+      params.type = cardTypeFilter
+        ? cardTypeFilter
+        : 'Unit,Event,Upgrade';
+      if (filterAspects.length) params.aspect = filterAspects.join(',');
+      if (filterTraits.length) params.trait = filterTraits.join(',');
+      if (filterSets.length) params.set = filterSets.join(',');
+    }
+
+    try {
+      const response = await fetchCards(params);
+      const newCards = Array.isArray(response.data) ? response.data : [];
+      const meta = response.meta || { pages: 1 };
+      setCards(prev => append ? [...prev, ...newCards] : newCards);
+      setHasMoreCards((meta.pages || 1) > page);
+      setCurrentPage(page);
+    } catch (err) {
+      setError(`Failed to load cards: ${err instanceof Error ? err.message : 'Unknown'}`);
+    } finally {
+      setLoading(false);
+      setIsLoadingMore(false);
+      loadingRef.current = false;
+    }
+  }, [currentStage, searchQuery, filterAspects, filterTraits, filterSets, cardTypeFilter, hasMoreCards]);
+
+  // Load existing deck
+  useEffect(() => {
+    if (!deckIdParam || isPotentialLoop) { setLoadingDeck(false); return; }
+    const processedId = sessionStorage.getItem('processedDeckId');
+    if (processedId === deckIdParam) { setLoadingDeck(false); if (currentStage !== 'cards') contextSetCurrentStage('cards'); return; }
+
+    const load = async () => {
+      setLoadingDeck(true);
+      try {
+        sessionStorage.setItem('processedDeckId', deckIdParam);
+        const data = await fetchWithAuth(`/api/me/get-deck?id=${encodeURIComponent(deckIdParam)}`);
+        if (!data?.id) throw new Error('Invalid deck data');
+        resetDeck();
+        setDeckName(data.name || 'Untitled Deck');
+        data.leaders?.forEach((l: CardType) => l?.id && addLeader(l));
+        if (data.base?.id) setBaseContext(data.base);
+        data.cards?.forEach((item: { card: CardType; quantity: number }) => item.card?.id && addCard(item.card));
+        contextSetCurrentStage('cards');
+      } catch (err) {
+        setError(`Failed to load deck: ${err instanceof Error ? err.message : 'Unknown'}`);
+        sessionStorage.removeItem('processedDeckId');
+      } finally { setLoadingDeck(false); }
+    };
+    load();
+  }, [deckIdParam, isPotentialLoop]);
+
+  // Reload cards when stage/filters change
+  useEffect(() => {
+    if (isPotentialLoop) return;
+    const key = `${currentStage}-${searchQuery}-${filterAspects.join(',')}-${filterTraits.join(',')}-${filterSets.join(',')}-${cardTypeFilter}`;
+    if (cardLoadingStageRef.current === key) return;
+    cardLoadingStageRef.current = key;
+    setCards([]);
+    setCurrentPage(1);
+    setHasMoreCards(true);
+    loadCards(1, false);
+  }, [currentStage, searchQuery, filterAspects, filterTraits, filterSets, cardTypeFilter, loadCards, isPotentialLoop]);
+
+  const debouncedSearch = useMemo(
+    () => debounce((q: string) => setSearchQuery(q), SEARCH_DEBOUNCE_MS),
+    []
+  );
+
+  // Client-side filtering
+  const displayedCards = useMemo(() => {
+    let filtered = cards;
+
+    if (currentStage === 'leaders' && leaders.length === 1) {
+      const first = leaders[0];
+      const firstAspects = first.aspects?.map(a => a.aspect_name) ?? [];
+      filtered = filtered.filter(card => {
+        if (card.id === first.id) return false;
+        const cardAspects = card.aspects?.map(a => a.aspect_name) ?? [];
+        if (firstAspects.includes('Heroism') && cardAspects.includes('Villainy')) return false;
+        if (firstAspects.includes('Villainy') && cardAspects.includes('Heroism')) return false;
+        return firstAspects.some(a => cardAspects.includes(a));
+      });
+    }
+    if (currentStage === 'leaders') {
+      const ids = new Set(leaders.map(l => l.id));
+      filtered = filtered.filter(c => !ids.has(c.id));
+    }
+    if (currentStage === 'cards' && hideCardsInDeck) {
+      const deckIds = new Set(deckCards.map(dc => dc.card.id));
+      filtered = filtered.filter(c => !deckIds.has(c.id));
+    }
+    if (currentStage === 'cards' && !showAllCards && leaders.length === 2 && base) {
+      filtered = filtered.filter(c => isCardInAspect(c));
+    }
+    return filtered;
+  }, [cards, currentStage, leaders, base, hideCardsInDeck, showAllCards, deckCards, isCardInAspect]);
+
+  const handleAddCard = useCallback((card: CardType) => {
+    if (currentStage === 'leaders') {
+      if (leaders.length < 2 && !leaders.some(l => l.id === card.id)) addLeader(card);
+    } else if (currentStage === 'base') {
+      if (card.type === 'Base' && !base) setBaseContext(card);
+    } else {
+      if (!isCardIdInDeck(card.id)) addCard(card);
+    }
+  }, [currentStage, leaders, base, addLeader, setBaseContext, addCard, isCardIdInDeck]);
+
+  const handleRemoveFromDeck = useCallback((id: string) => {
+    if (leaders.some(l => l.id === id)) removeLeader(id);
+    else if (base?.id === id) setBaseContext(null);
+    else removeCard(id);
+  }, [leaders, base, removeLeader, setBaseContext, removeCard]);
+
+  if (isPotentialLoop) {
+    return (
+      <div style={{ minHeight: '100vh', background: 'var(--ts-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ textAlign: 'center', border: '1px solid var(--ts-red)', padding: 32, maxWidth: 400 }}>
+          <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'var(--ts-red)', marginBottom: 12 }}>Loop Detected</div>
+          <p style={{ color: 'var(--ts-ink-2)', marginBottom: 16 }}>Too many rapid renders. Deck loading halted.</p>
+          <button
+            className="ts-btn ts-btn-sm"
+            onClick={() => { sessionStorage.clear(); window.location.reload(); }}
+            style={{ borderColor: 'var(--ts-red)', color: 'var(--ts-red)' }}
+          >
+            Clear & Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const colHeight = 'calc(100vh - 90px)'; // nav (60) + status strip (30)
+
+  return (
+    <div style={{ background: 'var(--ts-bg)', minHeight: '100vh' }}>
+      {/* Top toolbar */}
+      <div
+        style={{
+          padding: '10px 24px',
+          background: 'var(--ts-panel)',
+          borderBottom: '1px solid var(--ts-line)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+        }}
+      >
+        <div className="ts-eyebrow">Atelier · Construction</div>
+        <div style={{ width: 1, height: 18, background: 'var(--ts-line)' }} />
+        <div style={{ flex: 1, position: 'relative', maxWidth: 520 }}>
+          <svg
+            width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+            style={{ position: 'absolute', left: 11, top: '50%', transform: 'translateY(-50%)', color: 'var(--ts-ink-3)' }}
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            className="ts-input"
+            placeholder="Search cards…"
+            onChange={e => debouncedSearch(e.target.value)}
+            style={{ paddingLeft: 32, fontSize: 13 }}
+          />
+        </div>
+
+        {/* Stage selector */}
+        <div style={{ display: 'flex', gap: 0, border: '1px solid var(--ts-line-2)' }}>
+          {(['leaders', 'base', 'cards'] as const).map(stage => (
+            <button
+              key={stage}
+              onClick={() => contextSetCurrentStage(stage)}
+              style={{
+                padding: '5px 14px',
+                fontFamily: 'var(--ts-font-mono)',
+                fontSize: 9,
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+                background: currentStage === stage ? 'var(--ts-amber)' : 'transparent',
+                color: currentStage === stage ? '#1a1611' : 'var(--ts-ink-3)',
+                border: 'none',
+                borderRight: stage !== 'cards' ? '1px solid var(--ts-line-2)' : 'none',
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+              }}
+            >
+              {stage.charAt(0).toUpperCase() + stage.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <span
+          style={{
+            fontFamily: 'var(--ts-font-mono)',
+            fontSize: 11,
+            letterSpacing: '0.14em',
+            color: totalCards >= 30 ? 'var(--ts-green)' : 'var(--ts-amber)',
+          }}
+        >
+          ◉ {totalCards} / 30 CARDS
+        </span>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            padding: '10px 24px',
+            background: 'rgba(255,61,46,0.1)',
+            borderBottom: '1px solid var(--ts-red)',
+            display: 'flex',
+            gap: 12,
+            alignItems: 'center',
+          }}
+        >
+          <span style={{ color: 'var(--ts-red)', fontFamily: 'var(--ts-font-mono)', fontSize: 11 }}>{error}</span>
+          <button
+            className="ts-btn ts-btn-sm"
+            onClick={() => setError(null)}
+            style={{ borderColor: 'var(--ts-red)', color: 'var(--ts-red)' }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Stage banner (leaders / base) */}
+      {currentStage !== 'cards' && (
+        <div style={{ padding: '0 0' }}>
+          <StageBanner
+            currentStage={currentStage}
+            leaders={leaders}
+            base={base}
+            resetDeck={resetDeck}
+            setStage={contextSetCurrentStage}
+            handleRemoveFromDeck={handleRemoveFromDeck}
+          />
+        </div>
+      )}
+
+      {/* 3-column builder grid */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: currentStage === 'cards' ? '260px 1fr 340px' : '1fr',
+          borderTop: '1px solid var(--ts-line)',
+          height: currentStage === 'cards' ? colHeight : undefined,
+          minHeight: currentStage !== 'cards' ? '60vh' : undefined,
+        }}
+      >
+        {/* Left: filters */}
+        {currentStage === 'cards' && (
+          <FilterSidebar
+            filterAspects={filterAspects} setFilterAspects={setFilterAspects}
+            filterTraits={filterTraits} setFilterTraits={setFilterTraits}
+            filterSets={filterSets} setFilterSets={setFilterSets}
+            cardTypeFilter={cardTypeFilter} setCardTypeFilter={setCardTypeFilter}
+            availableAspects={availableAspects}
+            availableTraits={availableTraits}
+            availableSets={availableSets}
+            showAllCards={showAllCards} setShowAllCards={setShowAllCards}
+            hideCardsInDeck={hideCardsInDeck} setHideCardsInDeck={setHideCardsInDeck}
+            currentStage={currentStage}
+          />
+        )}
+
+        {/* Middle: card list (always shown) */}
+        <div
+          style={{
+            background: 'var(--ts-bg)',
+            borderRight: '1px solid var(--ts-line)',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {currentStage === 'cards' ? (
+            <CardListView
+              cards={displayedCards}
+              deck={{ cards: deckCards }}
+              addCard={handleAddCard}
+              removeCard={handleRemoveFromDeck}
+              loading={loading}
+              hasMoreCards={hasMoreCards}
+              isLoadingMore={isLoadingMore}
+              loadMore={() => loadCards(currentPage + 1, true)}
+              isCardInDeck={isCardIdInDeck}
+            />
+          ) : (
+            /* Leaders / base: grid of card images */
+            <div style={{ padding: 16, overflowY: 'auto' }}>
+              {loading ? (
+                <div
+                  style={{
+                    height: 200,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: 'var(--ts-ink-3)',
+                    fontFamily: 'var(--ts-font-mono)',
+                    fontSize: 11,
+                  }}
+                >
+                  Loading…
+                </div>
+              ) : (
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+                    gap: 10,
+                  }}
+                >
+                  {displayedCards.map(card => (
+                    <div
+                      key={card.id}
+                      onClick={() => handleAddCard(card)}
+                      style={{
+                        cursor: 'pointer',
+                        border: '1px solid var(--ts-line)',
+                        overflow: 'hidden',
+                        transition: 'border-color 0.15s',
+                        position: 'relative',
+                      }}
+                      onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--ts-amber)'; }}
+                      onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--ts-line)'; }}
+                    >
+                      <div style={{ aspectRatio: '7/10' }}>
+                        <img
+                          src={card.image_uri ?? '/placeholder-card.png'}
+                          alt={card.name}
+                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                          onError={e => { (e.target as HTMLImageElement).src = '/placeholder-card.png'; }}
+                        />
+                      </div>
+                      <div
+                        style={{
+                          padding: '5px 6px',
+                          background: 'var(--ts-panel)',
+                          borderTop: '1px solid var(--ts-line)',
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontFamily: 'var(--ts-font-display)',
+                            fontSize: 12,
+                            color: 'var(--ts-ink)',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {card.name}
+                        </div>
+                        <div style={{ display: 'flex', gap: 3, marginTop: 3 }}>
+                          {card.aspects?.map(a => (
+                            <AspectPip key={a.aspect_name} aspect={a.aspect_name} />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {hasMoreCards && !loading && displayedCards.length > 0 && (
+                <div style={{ textAlign: 'center', marginTop: 16 }}>
+                  <button
+                    className="ts-btn ts-btn-sm"
+                    onClick={() => loadCards(currentPage + 1, true)}
+                    disabled={isLoadingMore}
+                  >
+                    {isLoadingMore ? 'Loading…' : 'Load More'}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Right: deck panel */}
+        {currentStage === 'cards' && (
+          <div
+            style={{
+              background: 'var(--ts-panel)',
+              padding: '18px 14px',
+              overflowY: 'auto',
+            }}
+          >
+            <DeckPanel
+              deckCards={deckCards}
+              leaders={leaders}
+              base={base}
+              deckName={deckName}
+              setDeckName={setDeckName}
+              addCard={addCard}
+              removeCard={handleRemoveFromDeck}
+              openHandSim={() => setHandSimMode('sim')}
+              openMulligan={() => setHandSimMode('mulligan')}
+              onSave={() => setShowSaveDialog(true)}
+              totalCards={totalCards}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Modals */}
+      <SaveDeckDialog
+        isOpen={showSaveDialog}
+        onClose={() => setShowSaveDialog(false)}
+        existingDeckId={deckIdParam || undefined}
+        onSuccess={() => { setShowSaveDialog(false); router.push('/profile'); }}
+      />
+
+      {handSimMode && (
+        <HandSimModal
+          deckCards={deckCards}
+          mode={handSimMode}
+          onClose={() => setHandSimMode(null)}
+        />
+      )}
+    </div>
+  );
 }

--- a/frontend/src/app/deck-builder/HandSimModal.tsx
+++ b/frontend/src/app/deck-builder/HandSimModal.tsx
@@ -1,0 +1,437 @@
+// frontend/src/app/deck-builder/HandSimModal.tsx
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Card as CardType } from '@/lib/api';
+
+interface DeckItem {
+  card: CardType;
+  quantity: number;
+}
+
+interface Props {
+  deckCards: DeckItem[];
+  mode: 'sim' | 'mulligan';
+  onClose: () => void;
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function buildPool(deckCards: DeckItem[]): CardType[] {
+  const pool: CardType[] = [];
+  deckCards.forEach(({ card, quantity }) => {
+    for (let i = 0; i < quantity; i++) pool.push(card);
+  });
+  return pool;
+}
+
+function MiniCard({ card }: { card: CardType }) {
+  const aspects = card.aspects?.map(a => a.aspect_name) ?? [];
+  const ASPECT_COLORS: Record<string, string> = {
+    Command: '#c2453a', Aggression: '#d96f2d', Cunning: '#e2b342',
+    Heroism: '#ead7a8', Vigilance: '#4a90c4', Villainy: '#2c2a26',
+  };
+  const bg = aspects.length === 1
+    ? `linear-gradient(155deg, ${ASPECT_COLORS[aspects[0]] ?? '#2c251a'}, #2c251a)`
+    : aspects.length >= 2
+    ? `linear-gradient(155deg, ${aspects.map(a => ASPECT_COLORS[a] ?? '#2c251a').join(', ')})`
+    : 'linear-gradient(155deg, #2c251a, #1f1a12)';
+
+  const cost = card.cost ?? card.energy_cost ?? '—';
+
+  return (
+    <div
+      className="ts-mini-card"
+      style={{
+        width: 90,
+        aspectRatio: '5 / 7',
+        background: bg,
+        border: '1px solid var(--ts-line-2)',
+        position: 'relative',
+        boxShadow: '0 6px 18px rgba(0,0,0,0.4)',
+        flexShrink: 0,
+      }}
+    >
+      {/* Cost */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 5,
+          left: 5,
+          width: 20,
+          height: 20,
+          background: 'rgba(0,0,0,0.7)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'var(--ts-font-mono)',
+          fontSize: 12,
+          fontWeight: 700,
+          color: '#fff',
+        }}
+      >
+        {cost}
+      </div>
+
+      {/* Aspect pips */}
+      <div style={{ position: 'absolute', top: 5, right: 5, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {aspects.map(a => (
+          <span
+            key={a}
+            style={{
+              width: 14,
+              height: 14,
+              background: ASPECT_COLORS[a] ?? '#555',
+              clipPath: 'polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)',
+              display: 'inline-block',
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Name plate */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'rgba(20,16,10,0.92)',
+          padding: '4px 5px',
+          borderTop: '1px solid rgba(255,255,255,0.15)',
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'var(--ts-font-display)',
+            fontSize: 9,
+            color: '#e8dcc4',
+            lineHeight: 1.2,
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
+          {card.name}
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--ts-font-mono)',
+            fontSize: 7,
+            color: 'rgba(255,255,255,0.45)',
+            letterSpacing: '0.1em',
+            marginTop: 1,
+            textTransform: 'uppercase',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {card.type}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div className="ts-eyebrow" style={{ marginBottom: 4 }}>{label}</div>
+      <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, lineHeight: 1, color: 'var(--ts-ink)' }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function HandSimModal({ deckCards, mode, onClose }: Props) {
+  const pool = buildPool(deckCards);
+  const [hand, setHand] = useState<CardType[]>(() => shuffle(pool).slice(0, 6));
+  const [mulligans, setMulligans] = useState(0);
+  const [opponent, setOpponent] = useState('Sabine Wren');
+
+  const doMulligan = useCallback(() => {
+    setHand(shuffle(pool).slice(0, 6));
+    setMulligans(m => m + 1);
+  }, [pool]);
+
+  const drawOne = useCallback(() => {
+    const extended = shuffle(pool).slice(0, 6 + hand.length);
+    setHand(extended.slice(0, hand.length + 1));
+  }, [pool, hand.length]);
+
+  const reset = useCallback(() => {
+    setHand(shuffle(pool).slice(0, 6));
+    setMulligans(0);
+  }, [pool]);
+
+  // Stats
+  const avgCost = hand.length
+    ? (hand.reduce((s, c) => s + (c.cost ?? c.energy_cost ?? 0), 0) / hand.length).toFixed(1)
+    : '—';
+  const oneDrops = hand.filter(c => (c.cost ?? c.energy_cost ?? 0) <= 1).length;
+  const earlyUnits = hand.filter(
+    c => c.type?.toLowerCase().includes('unit') && (c.cost ?? c.energy_cost ?? 0) <= 3
+  ).length;
+
+  const verdict =
+    earlyUnits >= 2 && oneDrops >= 1
+      ? { label: 'KEEP', color: 'var(--ts-green)' }
+      : earlyUnits >= 2
+      ? { label: 'KEEP', color: 'var(--ts-amber)' }
+      : { label: 'MULLIGAN', color: 'var(--ts-red)' };
+
+  return (
+    <div className="ts-modal-backdrop" onClick={onClose}>
+      <div className="ts-modal" onClick={e => e.stopPropagation()}>
+        {/* Header */}
+        <div
+          style={{
+            padding: '18px 24px',
+            borderBottom: '1px solid var(--ts-line)',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <div className="ts-eyebrow" style={{ marginBottom: 4 }}>
+              {mode === 'mulligan' ? 'Mulligan Trainer' : 'Opening Hand Simulator'}
+            </div>
+            <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'var(--ts-ink)' }}>
+              {mode === 'mulligan' ? 'Train your mulligan instinct' : 'Sample your opener'}
+            </div>
+          </div>
+          <button
+            className="ts-btn ts-btn-sm"
+            onClick={onClose}
+          >
+            ✕ Close
+          </button>
+        </div>
+
+        <div style={{ padding: '24px 28px' }}>
+          {/* Matchup context (mulligan mode only) */}
+          {mode === 'mulligan' && (
+            <div
+              style={{
+                background: 'var(--ts-bg-2)',
+                border: '1px solid var(--ts-line)',
+                padding: '14px 18px',
+                marginBottom: 20,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 20,
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <div className="ts-eyebrow" style={{ marginBottom: 6 }}>Matchup Context</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-3)', letterSpacing: '0.1em', flexShrink: 0 }}>vs.</span>
+                  <input
+                    className="ts-input"
+                    style={{ flex: 1, padding: '4px 10px', fontSize: 15, fontFamily: 'var(--ts-font-display)', color: 'var(--ts-ink)', background: 'transparent', border: 'none', borderBottom: '1px solid var(--ts-line-2)', outline: 'none' }}
+                    value={opponent}
+                    onChange={e => setOpponent(e.target.value)}
+                    placeholder="Opponent leader…"
+                    spellCheck={false}
+                  />
+                </div>
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 9,
+                  color: 'var(--ts-ink-3)',
+                  letterSpacing: '0.14em',
+                  textAlign: 'right',
+                  flexShrink: 0,
+                }}
+              >
+                MULLIGAN AGAINST:<br />
+                {opponent || '—'}
+              </div>
+            </div>
+          )}
+
+          {/* Hand zone */}
+          <div className="ts-hand-zone">
+            {hand.length === 0 ? (
+              <div
+                style={{
+                  color: 'var(--ts-ink-3)',
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 11,
+                  letterSpacing: '0.16em',
+                }}
+              >
+                No cards in deck
+              </div>
+            ) : (
+              hand.map((card, i) => <MiniCard key={`${card.id}-${i}`} card={card} />)
+            )}
+          </div>
+
+          {/* Verdict + stats */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 20, marginTop: 20 }}>
+            {/* Verdict */}
+            <div
+              style={{
+                background: 'var(--ts-bg-2)',
+                border: '1px solid var(--ts-line)',
+                padding: 18,
+                textAlign: 'center',
+              }}
+            >
+              <div className="ts-eyebrow" style={{ marginBottom: 8 }}>Recommendation</div>
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-display)',
+                  fontSize: 40,
+                  lineHeight: 1,
+                  color: verdict.color,
+                }}
+              >
+                {verdict.label}
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 9,
+                  color: 'var(--ts-ink-3)',
+                  letterSpacing: '0.16em',
+                  marginTop: 8,
+                }}
+              >
+                {earlyUnits} EARLY UNITS · {oneDrops} ONE-DROP
+              </div>
+            </div>
+
+            {/* Stats */}
+            <div
+              style={{
+                background: 'var(--ts-bg-2)',
+                border: '1px solid var(--ts-line)',
+                padding: 18,
+              }}
+            >
+              <div className="ts-eyebrow" style={{ marginBottom: 14 }}>Hand Readout</div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+                <Stat label="Avg Cost" value={avgCost} />
+                <Stat label="One-Drops" value={oneDrops} />
+                <Stat label="Early Units" value={`${earlyUnits}/3`} />
+                <Stat label="Mulligans" value={mulligans} />
+              </div>
+
+              {/* Mini curve of hand */}
+              <div style={{ marginTop: 18, display: 'flex', gap: 3, height: 28, alignItems: 'flex-end' }}>
+                {Array(8).fill(0).map((_, i) => {
+                  const n = hand.filter(c => (i === 7 ? (c.cost ?? 0) >= 7 : (c.cost ?? 0) === i)).length;
+                  return (
+                    <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                      <div
+                        style={{
+                          background: 'var(--ts-amber)',
+                          width: '100%',
+                          height: n * 10,
+                          minHeight: n > 0 ? 4 : 0,
+                        }}
+                      />
+                      <div
+                        style={{
+                          fontFamily: 'var(--ts-font-mono)',
+                          fontSize: 8,
+                          color: 'var(--ts-ink-4)',
+                          textAlign: 'center',
+                        }}
+                      >
+                        {i === 7 ? '7+' : i}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* Controls */}
+          <div
+            style={{
+              display: 'flex',
+              gap: 10,
+              marginTop: 20,
+              justifyContent: 'center',
+            }}
+          >
+            <button className="ts-btn ts-btn-primary" onClick={doMulligan}>↻ Mulligan</button>
+            <button className="ts-btn" onClick={drawOne} disabled={hand.length >= pool.length}>+ Draw Card</button>
+            <button className="ts-btn" onClick={reset}>Reset</button>
+          </div>
+
+          {/* Veteran tips (mulligan mode) */}
+          {mode === 'mulligan' && (
+            <div
+              style={{
+                background: 'var(--ts-bg-2)',
+                border: '1px solid var(--ts-line)',
+                padding: '18px 20px',
+                marginTop: 20,
+              }}
+            >
+              <div className="ts-eyebrow" style={{ marginBottom: 14 }}>What Veterans Look For</div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 20 }}>
+                {[
+                  {
+                    t: 'Floor',
+                    d: '1 unit by turn 2 OR a 1-cost interaction. Otherwise mulligan.',
+                  },
+                  {
+                    t: 'Curve Target',
+                    d: 'Aim for 1-2-3 develop. 4+ cost cards with no early board = mull.',
+                  },
+                  {
+                    t: 'Aggro Matchup',
+                    d: 'Need defensive bodies turns 2-3. Early blockers are gold.',
+                  },
+                ].map(tip => (
+                  <div key={tip.t}>
+                    <div
+                      style={{
+                        fontFamily: 'var(--ts-font-display)',
+                        fontSize: 16,
+                        color: 'var(--ts-amber)',
+                        marginBottom: 6,
+                      }}
+                    >
+                      {tip.t}
+                    </div>
+                    <p
+                      style={{
+                        color: 'var(--ts-ink-2)',
+                        fontSize: 13,
+                        lineHeight: 1.6,
+                        margin: 0,
+                      }}
+                    >
+                      {tip.d}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,124 +1,463 @@
 /* src/app/globals.css */
 @import "tailwindcss";
 
-/* Force dark theme regardless of system preferences */
+/* ============================================================
+   Twin Suns — design tokens
+   "Imperial Field Manual" — desert tan parchment + saber accents
+   ============================================================ */
 :root {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  /* Palette: desert (default) */
+  --ts-bg: #1a1611;
+  --ts-bg-2: #221c14;
+  --ts-bg-3: #2a2419;
+  --ts-panel: #1f1a12;
+  --ts-panel-2: #2c251a;
+  --ts-line: #3d3527;
+  --ts-line-2: #4d4332;
+  --ts-ink: #e8dcc4;
+  --ts-ink-2: #c9b896;
+  --ts-ink-3: #8a7a5d;
+  --ts-ink-4: #5a4f3c;
+  --ts-paper: #d9c9a8;
+
+  /* Lightsaber accents */
+  --ts-red: #ff3d2e;
+  --ts-red-glow: rgba(255, 61, 46, 0.45);
+  --ts-blue: #4eb6ff;
+  --ts-blue-glow: rgba(78, 182, 255, 0.45);
+  --ts-green: #6ee36b;
+  --ts-green-glow: rgba(110, 227, 107, 0.45);
+  --ts-amber: #ffb454;
+
+  /* Aspect colors — faded-stamp */
+  --ts-aspect-command: #c2453a;
+  --ts-aspect-aggression: #d96f2d;
+  --ts-aspect-cunning: #e2b342;
+  --ts-aspect-heroism: #ead7a8;
+  --ts-aspect-vigilance: #4a90c4;
+  --ts-aspect-villainy: #4a4038;
+
+  /* Typography */
+  --ts-font-display: 'Cormorant Garamond', 'Cormorant', Georgia, serif;
+  --ts-font-body: 'Spectral', 'EB Garamond', Georgia, serif;
+  --ts-font-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace;
+
+  /* Texture */
+  --ts-grain-opacity: 0.14;
+  --ts-scanline-opacity: 0.0;
+
+  /* Tailwind compat */
+  --background: #1a1611;
+  --foreground: #e8dcc4;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
-/* Remove the media query that was causing the light mode default */
-/* This ensures the app is always in dark mode */
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--ts-bg);
+  color: var(--ts-ink);
+  font-family: var(--ts-font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
 }
 
-/* Twin Suns Gradient Definition */
+/* Paper-grain overlay */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.6  0 0 0 0 0.5  0 0 0 0 0.35  0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.5'/></svg>");
+  opacity: var(--ts-grain-opacity);
+  mix-blend-mode: overlay;
+}
+
+/* ============================================================
+   Typography
+   ============================================================ */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--ts-font-display);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  margin: 0;
+  color: var(--ts-ink);
+}
+
+h1 { font-size: clamp(36px, 5vw, 64px); line-height: 1.05; }
+h2 { font-size: clamp(24px, 3vw, 38px); line-height: 1.1; }
+h3 { font-size: 20px; line-height: 1.2; }
+
+a { color: inherit; }
+
+/* ============================================================
+   Twin Suns shared utilities
+   ============================================================ */
+.ts-eyebrow {
+  font-family: var(--ts-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ts-ink-3);
+}
+.ts-mono { font-family: var(--ts-font-mono); }
+.ts-display { font-family: var(--ts-font-display); }
+
+.ts-panel {
+  background: var(--ts-panel);
+  border: 1px solid var(--ts-line);
+}
+
+/* Hairline rule */
+.ts-rule {
+  height: 1px;
+  background: var(--ts-line);
+  border: 0;
+  margin: 0;
+}
+
+.ts-rule-double {
+  height: 5px;
+  border-top: 1px solid var(--ts-line);
+  border-bottom: 1px solid var(--ts-line);
+  margin: 0;
+}
+
+/* Saber glow line */
+.ts-saber-line {
+  height: 2px;
+  background: linear-gradient(to right, transparent, var(--ts-amber), transparent);
+  box-shadow: 0 0 8px var(--ts-amber);
+  border: 0;
+  margin: 0;
+}
+
+/* Aspect pip — hexagonal stamp */
+.ts-aspect-pip {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--ts-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  color: #1a1611;
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+  flex-shrink: 0;
+}
+.ts-aspect-pip[data-aspect="Command"]    { background: var(--ts-aspect-command); color: #fff; }
+.ts-aspect-pip[data-aspect="Aggression"] { background: var(--ts-aspect-aggression); }
+.ts-aspect-pip[data-aspect="Cunning"]    { background: var(--ts-aspect-cunning); }
+.ts-aspect-pip[data-aspect="Heroism"]    { background: var(--ts-aspect-heroism); }
+.ts-aspect-pip[data-aspect="Vigilance"]  { background: var(--ts-aspect-vigilance); color: #fff; }
+.ts-aspect-pip[data-aspect="Villainy"]   { background: var(--ts-aspect-villainy); color: var(--ts-ink-2); border: 1px solid var(--ts-line-2); }
+
+/* Filter pill */
+.ts-filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: 1px solid var(--ts-line-2);
+  font-family: var(--ts-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  background: transparent;
+  color: var(--ts-ink-2);
+  transition: all 0.15s;
+}
+.ts-filter-pill:hover { border-color: var(--ts-amber); color: var(--ts-amber); }
+.ts-filter-pill.is-active {
+  background: var(--ts-amber);
+  color: #1a1611;
+  border-color: var(--ts-amber);
+}
+
+/* Dotted leader line */
+.ts-leader-line {
+  flex: 1;
+  border-bottom: 1px dotted var(--ts-line-2);
+  margin: 0 8px 4px;
+  min-width: 12px;
+}
+
+/* Chip */
+.ts-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--ts-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--ts-line-2);
+  color: var(--ts-ink-2);
+  background: transparent;
+  white-space: nowrap;
+}
+
+/* Stamp badge */
+.ts-stamp {
+  display: inline-block;
+  font-family: var(--ts-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ts-red);
+  border: 1.5px solid var(--ts-red);
+  padding: 3px 8px;
+  transform: rotate(-2deg);
+  opacity: 0.85;
+}
+
+/* Buttons */
+.ts-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 18px;
+  font-family: var(--ts-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 1px solid var(--ts-line-2);
+  background: transparent;
+  color: var(--ts-ink);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-decoration: none;
+  border-radius: 0;
+}
+.ts-btn:hover {
+  border-color: var(--ts-amber);
+  color: var(--ts-amber);
+}
+.ts-btn-primary {
+  background: var(--ts-amber);
+  color: #1a1611;
+  border-color: var(--ts-amber);
+}
+.ts-btn-primary:hover {
+  background: #ffc870;
+  color: #1a1611;
+  border-color: #ffc870;
+  box-shadow: 0 0 20px rgba(255, 180, 84, 0.4);
+}
+.ts-btn-sm { padding: 5px 12px; font-size: 9px; letter-spacing: 0.16em; }
+.ts-btn-blue {
+  border-color: var(--ts-blue);
+  color: var(--ts-blue);
+}
+.ts-btn-blue:hover {
+  background: var(--ts-blue);
+  color: #08111c;
+  box-shadow: 0 0 16px var(--ts-blue-glow);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--ts-bg); }
+::-webkit-scrollbar-thumb { background: var(--ts-line-2); }
+::-webkit-scrollbar-thumb:hover { background: var(--ts-ink-4); }
+
+/* Selection */
+::selection { background: var(--ts-amber); color: #1a1611; }
+
+/* Focus */
+:focus-visible {
+  outline: 2px solid var(--ts-amber);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Inputs
+   ============================================================ */
+.ts-input {
+  background: var(--ts-panel);
+  border: 1px solid var(--ts-line);
+  color: var(--ts-ink);
+  padding: 9px 13px;
+  font-family: var(--ts-font-body);
+  font-size: 14px;
+  width: 100%;
+  outline: none;
+}
+.ts-input:focus { border-color: var(--ts-amber); }
+.ts-input::placeholder { color: var(--ts-ink-4); }
+
+/* ============================================================
+   Status marquee animation
+   ============================================================ */
+@keyframes ts-marquee {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+.ts-marquee-track { animation: ts-marquee 70s linear infinite; }
+
+/* ============================================================
+   Coming Soon overlay
+   ============================================================ */
+.ts-coming-soon {
+  position: relative;
+  overflow: hidden;
+}
+.ts-coming-soon-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(26, 22, 17, 0.88);
+  backdrop-filter: blur(2px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  border: 1px solid var(--ts-line-2);
+}
+
+/* ============================================================
+   Curve chart
+   ============================================================ */
+.ts-curve-chart {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 4px;
+  height: 80px;
+  align-items: end;
+  border-bottom: 1px solid var(--ts-line-2);
+  padding-bottom: 4px;
+}
+.ts-curve-bar {
+  background: var(--ts-panel-2);
+  border: 1px solid var(--ts-line-2);
+  position: relative;
+  min-height: 4px;
+}
+.ts-curve-bar-fill {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  background: var(--ts-amber);
+  transition: height 0.25s;
+}
+
+/* ============================================================
+   Tabs — override Radix styles to use Twin Suns aesthetic
+   ============================================================ */
+.ts-tabs-list {
+  display: flex;
+  border-bottom: 1px solid var(--ts-line);
+  background: transparent;
+  gap: 0;
+  height: auto;
+  padding: 0;
+}
+.ts-tab-trigger {
+  padding: 11px 18px;
+  font-family: var(--ts-font-mono) !important;
+  font-size: 10px !important;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ts-ink-3);
+  border: 0;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border-radius: 0;
+  height: auto;
+}
+.ts-tab-trigger:hover { color: var(--ts-ink-2); }
+.ts-tab-trigger[data-state="active"] {
+  color: var(--ts-amber) !important;
+  border-bottom-color: var(--ts-amber);
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+/* Card row in deck builder middle column */
+.ts-card-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto 88px;
+  gap: 8px;
+  padding: 7px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--ts-line);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ts-card-row:hover { background: var(--ts-panel-2); }
+.ts-card-row:last-child { border-bottom: 0; }
+
+/* Deck card row in right panel */
+.ts-deck-row {
+  display: grid;
+  grid-template-columns: 22px 22px 1fr auto;
+  gap: 6px;
+  padding: 5px 8px;
+  align-items: center;
+  transition: background 0.1s;
+}
+.ts-deck-row:hover { background: var(--ts-panel-2); }
+
+/* Hand sim modal */
+.ts-hand-zone {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  padding: 28px 16px;
+  min-height: 260px;
+  align-items: center;
+  background: radial-gradient(ellipse at center bottom, rgba(255,180,84,0.05), transparent 60%), var(--ts-bg-2);
+  border: 1px solid var(--ts-line);
+}
+.ts-mini-card {
+  transition: transform 0.25s ease;
+  flex-shrink: 0;
+}
+.ts-mini-card:hover { transform: translateY(-10px); }
+
+/* Modal */
+.ts-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 8, 5, 0.88);
+  backdrop-filter: blur(4px);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.ts-modal {
+  background: var(--ts-bg);
+  border: 1px solid var(--ts-line-2);
+  width: 100%;
+  max-width: 1060px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+/* ============================================================
+   Tailwind-compatible legacy overrides
+   (kept so existing Tailwind classes still work on non-builder pages)
+   ============================================================ */
 .twin-suns-gradient {
-  background-image: linear-gradient(to right, #a855f7, #ec4899, #f97316);
+  background-image: linear-gradient(to right, var(--ts-amber), var(--ts-red));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   color: transparent;
   display: inline;
-  background-color: transparent !important;
-}
-
-/* Ensure the gradient is always applied with high specificity */
-h1 .twin-suns-gradient,
-h2 .twin-suns-gradient,
-.navbar .twin-suns-gradient,
-span.twin-suns-gradient {
-  background-image: linear-gradient(to right, #a855f7, #ec4899, #f97316) !important;
-  -webkit-background-clip: text !important;
-  -webkit-text-fill-color: transparent !important;
-  background-clip: text !important;
-  color: transparent !important;
-}
-
-/* Custom utility classes for text contrast - Tailwind-friendly */
-.section-heading {
-  @apply text-white font-medium;
-}
-
-.filter-label {
-  @apply text-gray-300 font-medium;
-}
-
-.stats-label {
-  @apply text-gray-300 font-medium;
-}
-
-/* Ensure specific headings have proper contrast */
-.card-browser-heading {
-  @apply text-white;
-}
-
-.deck-builder-heading {
-  @apply text-white;
-}
-
-.card-type-heading {
-  @apply text-white;
-}
-
-.aspects-heading {
-  @apply text-white;
-}
-
-.resource-cost-heading {
-  @apply text-white;
-}
-
-.energy-cost-heading {
-  @apply text-white;
-}
-
-.your-deck-heading {
-  @apply text-white;
-}
-
-.deck-stats-heading {
-  @apply text-white;
-}
-
-.card-count-heading {
-  @apply text-white;
-}
-
-/* Additional CSS for better contrast across the site */
-h1, h2, h3, h4, h5, h6 {
-  @apply text-white;
-}
-
-span, p, div {
-  @apply text-gray-300;
-}
-
-button, a {
-  @apply text-white;
-}
-
-/* Override for any text that still has contrast issues */
-.text-fix {
-  @apply text-white;
-}
-
-/* Force visible text on dark backgrounds */
-.dark-bg-text {
-  color: white !important; 
-}
-
-/* For any sections that were previously problematic */
-.force-visible {
-  color: white !important;
 }

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <circle cx="15" cy="24" r="12" fill="#ffb454" opacity="0.95"/>
+  <circle cx="28" cy="14" r="8" fill="#ff3d2e" opacity="0.9"/>
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,23 +1,34 @@
 // frontend/src/app/layout.tsx
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Cormorant_Garamond, Spectral, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/Navbar";
 import { AuthProvider } from "@/contexts/AuthContext";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const cormorant = Cormorant_Garamond({
+  variable: "--font-display",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const spectral = Spectral({
+  variable: "--font-body",
   subsets: ["latin"],
+  weight: ["300", "400", "500", "600"],
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
-  title: "Star Wars Unlimited Deck Builder",
-  description: "Build, share, and analyze Star Wars Unlimited decks",
+  title: "Twin Suns · Star Wars Unlimited",
+  description: "Field manual and deck atelier for Star Wars: Unlimited Twin Suns format.",
 };
 
 export default function RootLayout({
@@ -28,7 +39,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-black text-white`}
+        className={`${cormorant.variable} ${spectral.variable} ${jetbrainsMono.variable} antialiased`}
+        style={{
+          fontFamily: "var(--font-body, 'Spectral', Georgia, serif)",
+          background: "var(--ts-bg)",
+          color: "var(--ts-ink)",
+        }}
       >
         <AuthProvider>
           <Navbar />

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,129 +1,131 @@
 // frontend/src/app/login/page.tsx
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertTriangle } from "lucide-react";
+import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
-import { Suspense } from 'react';
-
 function LoginPageContent() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const redirectPath = searchParams.get('redirect') || '/profile'; // Default redirect
+  const searchParams = useSearchParams();
+  const redirectPath = searchParams.get('redirect') || '/profile';
+  const { login } = useAuth();
 
-    const { login } = useAuth(); // Get login function from context
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const [error, setError] = useState<string | null>(null);
-    const [isLoading, setIsLoading] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setIsLoading(true);
-        setError(null);
-        
-        try {
-            // Use the login function from auth context
-            console.log('Attempting to log in with:', username);
-            await login(username, password);
-            // Auth context will handle redirect
-        } catch (err) {
-            console.error('Login error:', err);
-            setError('Invalid username or password. Please try again.');
-        } finally {
-            setIsLoading(false);
-        }
-    };
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    try {
+      await login(username, password);
+    } catch {
+      setError('Invalid username or password. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-    return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-950 p-4">
-            <Card className="w-full max-w-md bg-gray-900 border-gray-800 text-white">
-                <CardHeader>
-                    <CardTitle className="text-2xl font-bold text-center">
-                        <span className="bg-gradient-to-r from-purple-500 via-pink-500 to-orange-500 bg-clip-text text-transparent">
-                            Welcome Back
-                        </span>
-                    </CardTitle>
-                    <CardDescription className="text-gray-400 text-center">
-                        Sign in to your account to access your decks and collection
-                    </CardDescription>
-                </CardHeader>
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--ts-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '40px 24px' }}>
+      <div style={{ width: '100%', maxWidth: 420 }}>
 
-                <CardContent>
-                    {error && (
-                        <Alert variant="destructive" className="mb-6 bg-red-900/30 border-red-800 text-red-300">
-                             <AlertTriangle className="h-4 w-4 !text-red-400" />
-                             <AlertTitle>Login Failed</AlertTitle>
-                             <AlertDescription>{error}</AlertDescription>
-                         </Alert>
-                    )}
-
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        <div className="space-y-2">
-                            <Label htmlFor="username">Username</Label>
-                            <Input
-                                id="username"
-                                name="username" 
-                                type="text"
-                                placeholder="Enter your username"
-                                value={username}
-                                onChange={(e) => setUsername(e.target.value)}
-                                className="bg-gray-800 border border-gray-700 focus:border-purple-500 focus:ring-purple-500" 
-                                disabled={isLoading}
-                                autoComplete="username"
-                            />
-                        </div>
-
-                        <div className="space-y-2">
-                            <Label htmlFor="password">Password</Label>
-                            <Input
-                                id="password"
-                                name="password"
-                                type="password"
-                                placeholder="Enter your password"
-                                value={password}
-                                onChange={(e) => setPassword(e.target.value)}
-                                className="bg-gray-800 border border-gray-700 focus:border-purple-500 focus:ring-purple-500"
-                                disabled={isLoading}
-                                autoComplete="current-password"
-                            />
-                        </div>
-
-                        <Button
-                            type="submit"
-                            className="w-full bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
-                            disabled={isLoading}
-                        >
-                            {isLoading ? 'Signing In...' : 'Sign In'}
-                        </Button>
-                    </form>
-                </CardContent>
-
-                <CardFooter className="flex justify-center">
-                    <p className="text-gray-400">
-                        Don't have an account?{' '}
-                        <Link href="/signup" className="text-purple-400 hover:underline">
-                            Sign Up
-                        </Link>
-                    </p>
-                </CardFooter>
-            </Card>
+        {/* Header */}
+        <div style={{ marginBottom: 40, textAlign: 'center' }}>
+          <div className="ts-eyebrow" style={{ marginBottom: 12 }}>Twin Suns · Field Access</div>
+          <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 36, color: 'var(--ts-ink)', lineHeight: 1.1 }}>
+            Welcome back,<br />Commander.
+          </div>
         </div>
-    );
+
+        {/* Card */}
+        <div style={{ background: 'var(--ts-bg-2)', border: '1px solid var(--ts-line)', padding: '36px 32px' }}>
+
+          {error && (
+            <div style={{ marginBottom: 24, padding: '12px 16px', border: '1px solid var(--ts-red)', background: 'rgba(255,61,46,0.08)' }}>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-red)', marginBottom: 4, textTransform: 'uppercase' }}>
+                Access Denied
+              </div>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 11, color: 'rgba(255,100,90,0.9)', letterSpacing: '0.06em' }}>
+                {error}
+              </div>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: 20 }}>
+              <label htmlFor="username" style={{ display: 'block', fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-ink-3)', textTransform: 'uppercase', marginBottom: 8 }}>
+                Callsign
+              </label>
+              <input
+                id="username"
+                name="username"
+                type="text"
+                className="ts-input"
+                style={{ width: '100%' }}
+                placeholder="Enter your username"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+                disabled={isLoading}
+                autoComplete="username"
+                required
+              />
+            </div>
+
+            <div style={{ marginBottom: 28 }}>
+              <label htmlFor="password" style={{ display: 'block', fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-ink-3)', textTransform: 'uppercase', marginBottom: 8 }}>
+                Security Code
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                className="ts-input"
+                style={{ width: '100%' }}
+                placeholder="Enter your password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                disabled={isLoading}
+                autoComplete="current-password"
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              className="ts-btn ts-btn-primary"
+              style={{ width: '100%', justifyContent: 'center', fontSize: 11, letterSpacing: '0.22em', padding: '14px 24px', opacity: isLoading ? 0.6 : 1 }}
+              disabled={isLoading}
+            >
+              {isLoading ? 'AUTHENTICATING...' : 'ENTER THE ATELIER →'}
+            </button>
+          </form>
+
+          <div className="ts-rule" style={{ margin: '24px 0' }} />
+
+          <div style={{ textAlign: 'center', fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-3)', letterSpacing: '0.12em' }}>
+            No account?{' '}
+            <Link href="/signup" style={{ color: 'var(--ts-amber)', textDecoration: 'none' }}>
+              Enlist now
+            </Link>
+          </div>
+        </div>
+
+        <div style={{ marginTop: 24, textAlign: 'center', fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-ink-4)', letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+          Twin Suns · Star Wars Unlimited · Twin Suns Format
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function LoginPage() {
-    return (
-        <Suspense fallback={<div>Loading...</div>}>
-            <LoginPageContent />
-        </Suspense>
-    );
+  return (
+    <Suspense fallback={<div style={{ minHeight: '100vh', background: 'var(--ts-bg)' }} />}>
+      <LoginPageContent />
+    </Suspense>
+  );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,126 +3,336 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+
+const ASPECT_COLORS: Record<string, string> = {
+  Command: '#c2453a', Aggression: '#d96f2d', Cunning: '#e2b342',
+  Heroism: '#ead7a8', Vigilance: '#4a90c4', Villainy: '#2c2a26',
+};
+
+const SPOTLIGHT = {
+  title: "Sabine's Mandalorian Strike",
+  tier: 'S',
+  aspects: ['Aggression', 'Cunning'],
+  subline: 'RA × CU · AGGRO',
+  winRate: '64.2%', winN: 'n=1,418',
+  avgCost: '2.1', avgLabel: 'curve',
+  pilot: 'Ezra_S.', pilotLabel: "GCS '26",
+  units: 32, events: 14, upgrades: 4, total: 50,
+};
+
+const TRAINING_TRACKS = [
+  { rank: 'K1', label: 'Cadet',       desc: 'Build your first deck and simulate an opening hand.', progress: 100, complete: true },
+  { rank: 'K2', label: 'Pilot',       desc: 'Save three decks and run five mulligan sessions.',     progress: 60,  complete: false },
+  { rank: 'K3', label: 'Flight Lead', desc: 'Build a deck in each of the six aspects.',             progress: 33,  complete: false },
+  { rank: 'K4', label: 'Squadron',    desc: 'Log a tournament result and reach 20 deck saves.',     progress: 0,   complete: false },
+];
+
+const ASPECTS_GRID = [
+  { name: 'Command',    desc: 'Resources · Stability' },
+  { name: 'Aggression', desc: 'Damage · Tempo' },
+  { name: 'Cunning',    desc: 'Tricks · Value' },
+  { name: 'Heroism',    desc: 'Protection · Bond' },
+  { name: 'Vigilance',  desc: 'Control · Defense' },
+  { name: 'Villainy',   desc: 'Power · Fear' },
+];
+
+const COMING_SOON = [
+  { label: 'Collection Tracker', desc: 'Mark cards owned, track completion %' },
+  { label: 'Achievements',       desc: 'Pilot training milestones and seasonal tracks' },
+  { label: 'Tournament Log',     desc: 'Event results, ELO, head-to-head records' },
+  { label: 'Wishlist',           desc: 'Wishlist and trade binder management' },
+];
+
+const FEATURES = [
+  {
+    eyebrow: 'Intelligence', title: 'Card Codex', href: '/cards', cta: 'Open Codex',
+    accent: 'var(--ts-amber)',
+    body: '2,360+ cards indexed across all sets. Filter by aspect, type, trait, keyword, and arena. Every variant catalogued.',
+    icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>,
+  },
+  {
+    eyebrow: 'Construction', title: 'Deck Atelier', href: '/deck-builder', cta: 'Enter Atelier',
+    accent: 'var(--ts-blue)',
+    body: 'Three-stage build flow — leader, base, cards. Resource curve analysis, composition breakdown, and hand simulation.',
+    icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>,
+  },
+  {
+    eyebrow: 'Training', title: 'Hand Simulator', href: '/deck-builder', cta: 'Run Simulation',
+    accent: 'var(--ts-green)',
+    body: 'Draw opening hands from any saved deck. Mulligan trainer scores hands against veteran criteria: one-drops, early units, curve.',
+    icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/></svg>,
+  },
+];
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-black text-white">
-      {/* Hero Section */}
-      <section className="flex flex-col items-center justify-center text-center py-32 px-4">
-      <h1 className="text-6xl md:text-7xl font-bold mb-6">
-        Welcome to{" "}
-        <span className="twin-suns-gradient">Twin Suns</span>
-      </h1>
-        <p className="text-xl md:text-2xl text-gray-300 max-w-2xl mb-12">
-          The ultimate resource for Star Wars Unlimited players. Build, share, and discover.
-        </p>
-        <div className="flex flex-wrap gap-4 justify-center">
-          <Button asChild className="bg-gradient-to-r from-orange-600 to-orange-400 text-white hover:opacity-90 py-6 px-8 text-lg">
-            <Link href="/deck-builder">
-              <svg className="w-5 h-5 mr-2 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-              Start Building
-            </Link>
-          </Button>
-          <Button asChild className="bg-transparent border border-pink-500 text-pink-500 hover:bg-pink-500/10 py-6 px-8 text-lg">
-          <Link href="/cards">
-            <svg className="w-5 h-5 mr-2 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16m-7 6h7" />
-            </svg>
-            Browse Cards
-          </Link>
-        </Button>
+    <div style={{ minHeight: '100vh', background: 'var(--ts-bg)' }}>
+
+      {/* ══ HERO ══════════════════════════════════════════════════════════ */}
+      <section style={{ position: 'relative', overflow: 'hidden', minHeight: 640 }}>
+
+        {/* Amber sun — large, full-bleed behind content */}
+        <div style={{
+          position: 'absolute', top: -120, right: '12%',
+          width: 560, height: 560, borderRadius: '50%',
+          background: 'radial-gradient(circle at 38% 38%, #ffd98a, #ffb454 48%, #b86c10 80%)',
+          opacity: 0.93, zIndex: 1,
+        }} />
+
+        {/* Red sun — smaller, upper-right corner */}
+        <div style={{
+          position: 'absolute', top: -100, right: '-1%',
+          width: 360, height: 360, borderRadius: '50%',
+          background: 'radial-gradient(circle at 42% 36%, #ff8f85, #ff3d2e 52%, #8b1409 85%)',
+          opacity: 0.88, zIndex: 2,
+        }} />
+
+        {/* Scanlines over suns */}
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 3, pointerEvents: 'none',
+          backgroundImage: 'repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, rgba(10,8,4,0.2) 2px, rgba(10,8,4,0.2) 3px)',
+        }} />
+
+        {/* Left vignette — keeps text readable */}
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 4, pointerEvents: 'none',
+          background: 'linear-gradient(to right, var(--ts-bg) 38%, rgba(26,22,17,0.75) 58%, rgba(26,22,17,0.1) 75%, transparent)',
+        }} />
+
+        {/* Content grid */}
+        <div style={{
+          position: 'relative', zIndex: 5,
+          maxWidth: 1320, margin: '0 auto', padding: '80px 48px 88px',
+          display: 'grid', gridTemplateColumns: '1fr 460px', gap: 48,
+          alignItems: 'center', minHeight: 640,
+        }}>
+
+          {/* Left — copy */}
+          <div>
+            <div className="ts-eyebrow" style={{ marginBottom: 28, whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ color: 'var(--ts-amber)', fontSize: 10 }}>◇</span>
+              FIELD MANUAL · VOL. III · 34 ABY · 05.05
+            </div>
+            <h1 style={{
+              fontFamily: 'var(--ts-font-display)',
+              fontSize: 'clamp(56px, 6.5vw, 92px)',
+              lineHeight: 1.0, color: 'var(--ts-ink)', fontWeight: 600,
+              margin: '0 0 28px', letterSpacing: '-0.01em',
+            }}>
+              Build like a{' '}
+              <em style={{ color: 'var(--ts-amber)', fontStyle: 'italic' }}>Jedi.</em>{' '}
+              Win like a smuggler.
+            </h1>
+            <p style={{
+              fontFamily: 'var(--ts-font-body)', fontSize: 17, lineHeight: 1.75,
+              color: 'var(--ts-ink-2)', maxWidth: 520, margin: '0 0 44px',
+            }}>
+              Twin Suns is the deck atelier and field guide for veterans of{' '}
+              <strong style={{ color: 'var(--ts-ink)', fontWeight: 500 }}>Star Wars: Unlimited.</strong>{' '}
+              Pore over every printing, sweat the curve, drill mulligans, and post your list to the holonet.
+            </p>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              <Link href="/deck-builder" className="ts-btn ts-btn-primary" style={{ fontSize: 12, letterSpacing: '0.22em', padding: '12px 24px' }}>
+                OPEN ATELIER →
+              </Link>
+              <Link href="/cards" className="ts-btn" style={{ fontSize: 12, letterSpacing: '0.22em', padding: '12px 24px' }}>
+                BROWSE THE ARCHIVE
+              </Link>
+            </div>
+          </div>
+
+          {/* Right — spotlight card floats over suns */}
+          <div style={{ alignSelf: 'flex-end' }}>
+            <div style={{
+              background: 'rgba(20,16,10,0.92)', border: '1px solid var(--ts-line-2)',
+              padding: '22px 24px 20px',
+              boxShadow: '0 24px 64px rgba(0,0,0,0.75)', backdropFilter: 'blur(2px)',
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+                <div className="ts-eyebrow">Deck of the Cycle</div>
+                <span style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', border: '1px solid var(--ts-red)', color: 'var(--ts-red)', padding: '2px 8px' }}>
+                  TIER {SPOTLIGHT.tier}
+                </span>
+              </div>
+              <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 22, color: 'var(--ts-ink)', lineHeight: 1.1, marginBottom: 10 }}>
+                {SPOTLIGHT.title}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+                {SPOTLIGHT.aspects.map(a => (
+                  <span key={a} style={{ width: 20, height: 20, background: ASPECT_COLORS[a] ?? '#555', clipPath: 'polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)', display: 'inline-block', flexShrink: 0 }} />
+                ))}
+                <span style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.18em', color: 'var(--ts-ink-3)', textTransform: 'uppercase' }}>
+                  {SPOTLIGHT.subline}
+                </span>
+              </div>
+              <div className="ts-rule" style={{ margin: '0 0 14px' }} />
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 14 }}>
+                {[
+                  { label: 'Win Rate', value: SPOTLIGHT.winRate, sub: SPOTLIGHT.winN },
+                  { label: 'Avg Cost', value: SPOTLIGHT.avgCost, sub: SPOTLIGHT.avgLabel },
+                  { label: 'Pilot',    value: SPOTLIGHT.pilot,   sub: SPOTLIGHT.pilotLabel },
+                ].map(s => (
+                  <div key={s.label}>
+                    <div className="ts-eyebrow" style={{ marginBottom: 2, fontSize: 8 }}>{s.label}</div>
+                    <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 20, color: 'var(--ts-ink)', lineHeight: 1 }}>{s.value}</div>
+                    <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 8, color: 'var(--ts-ink-4)', marginTop: 2 }}>{s.sub}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="ts-rule" style={{ margin: '0 0 12px' }} />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 16 }}>
+                {[
+                  { label: 'Units',    n: SPOTLIGHT.units },
+                  { label: 'Events',   n: SPOTLIGHT.events },
+                  { label: 'Upgrades', n: SPOTLIGHT.upgrades },
+                  { label: 'Total',    n: SPOTLIGHT.total },
+                ].map(row => (
+                  <div key={row.label} style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: row.label === 'Total' ? 'var(--ts-ink-2)' : 'var(--ts-ink-3)', letterSpacing: '0.08em' }}>
+                    <span>{row.label}</span>
+                    <span>{String(row.n).padStart(2, '0')}</span>
+                  </div>
+                ))}
+              </div>
+              <button className="ts-btn ts-btn-blue" style={{ width: '100%', justifyContent: 'center', fontSize: 10, letterSpacing: '0.22em' }} disabled>
+                OPEN DECK →
+              </button>
+            </div>
+          </div>
+
         </div>
       </section>
 
-      {/* Feature Cards Section */}
-      <section className="py-16 px-4 bg-gray-950">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-4xl font-bold text-center mb-12 text-white">Key Features</h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {/* Card Browser Feature */}
-            <Card className="bg-gray-900 border-gray-800 hover:border-purple-500 transition-colors group">
-              <CardContent className="p-6">
-                <div className="h-12 w-12 rounded-lg bg-purple-900/30 flex items-center justify-center mb-4 group-hover:bg-purple-800/50 transition-colors">
-                  <svg className="h-6 w-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-                  </svg>
-                </div>
-                <h3 className="text-xl font-bold mb-2 text-white">Card Browser</h3>
-                <p className="text-gray-400 mb-4">
-                  Explore every card in Star Wars Unlimited with powerful filtering and search capabilities.
-                </p>
-                <Link href="/cards" className="text-purple-400 inline-flex items-center hover:underline group-hover:text-purple-300">
-                  Browse Cards
-                  <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-              </CardContent>
-            </Card>
+      {/* ══ FEATURE PANELS ═══════════════════════════════════════════════ */}
+      <section style={{ borderTop: '1px solid var(--ts-line)', borderBottom: '1px solid var(--ts-line)', background: 'var(--ts-bg-2)' }}>
+        <div style={{ maxWidth: 1320, margin: '0 auto', padding: '0 48px', display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)' }}>
+          {FEATURES.map((f, i) => (
+            <div key={f.title} style={{ padding: '48px 40px', borderRight: i < FEATURES.length - 1 ? '1px solid var(--ts-line)' : undefined }}>
+              <div style={{ width: 44, height: 44, border: `1px solid ${f.accent}`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: f.accent, marginBottom: 22 }}>
+                {f.icon}
+              </div>
+              <div className="ts-eyebrow" style={{ marginBottom: 8 }}>{f.eyebrow}</div>
+              <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'var(--ts-ink)', marginBottom: 12, lineHeight: 1.1 }}>{f.title}</div>
+              <p style={{ color: 'var(--ts-ink-2)', fontSize: 14, lineHeight: 1.7, marginBottom: 28, fontFamily: 'var(--ts-font-body)' }}>{f.body}</p>
+              <Link href={f.href} style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: f.accent, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                {f.cta} <span style={{ fontSize: 14 }}>→</span>
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
 
-            {/* Deck Builder Feature */}
-            <Card className="bg-gray-900 border-gray-800 hover:border-purple-500 transition-colors group">
-              <CardContent className="p-6">
-                <div className="h-12 w-12 rounded-lg bg-purple-900/30 flex items-center justify-center mb-4 group-hover:bg-purple-800/50 transition-colors">
-                  <svg className="h-6 w-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                  </svg>
+      {/* ══ PILOT TRAINING ═══════════════════════════════════════════════ */}
+      <section style={{ maxWidth: 1320, margin: '0 auto', padding: '80px 48px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '320px 1fr', gap: 72, alignItems: 'start' }}>
+          <div>
+            <div className="ts-eyebrow" style={{ marginBottom: 16 }}>Pilot Training</div>
+            <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 38, color: 'var(--ts-ink)', lineHeight: 1.05, marginBottom: 20 }}>
+              Earn your wings, Commander.
+            </div>
+            <p style={{ color: 'var(--ts-ink-2)', fontSize: 14, lineHeight: 1.75, fontFamily: 'var(--ts-font-body)', marginBottom: 28 }}>
+              Advance through ranks by building decks, drilling mulligans, and logging tournament results. Each rank unlocks profile badges and new field intel.
+            </p>
+            <Link href="/profile" className="ts-btn" style={{ fontSize: 10, letterSpacing: '0.2em' }}>
+              View Pilot Profile →
+            </Link>
+            <div style={{ marginTop: 24, padding: '12px 16px', background: 'var(--ts-bg-2)', border: '1px solid var(--ts-line)', fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-ink-4)', letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+              ◈ Sign in to track your progress
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 1, background: 'var(--ts-line)' }}>
+            {TRAINING_TRACKS.map((track, i) => (
+              <div key={track.rank} style={{ background: track.complete ? 'var(--ts-bg-2)' : 'var(--ts-bg)', padding: '20px 24px', display: 'grid', gridTemplateColumns: '56px 1fr auto', gap: 20, alignItems: 'center', opacity: i > 1 ? 0.55 : 1 }}>
+                <div style={{ width: 44, height: 44, border: `1px solid ${track.complete ? 'var(--ts-amber)' : 'var(--ts-line-2)'}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'var(--ts-font-mono)', fontSize: 11, letterSpacing: '0.1em', color: track.complete ? 'var(--ts-amber)' : 'var(--ts-ink-3)' }}>
+                  {track.rank}
                 </div>
-                <h3 className="text-xl font-bold mb-2 text-white">Twin Suns Deck Builder</h3>
-                <p className="text-gray-400 mb-4">
-                  Build your perfect deck for the Twin Suns format with our intuitive deck building tools.
-                </p>
-                <Link href="/deck-builder" className="text-purple-400 inline-flex items-center hover:underline group-hover:text-purple-300">
-                  Build a Deck
-                  <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-              </CardContent>
-            </Card>
-
-            {/* AI Companion Feature */}
-            <Card className="bg-gray-900 border-gray-800 hover:border-purple-500 transition-colors group">
-              <CardContent className="p-6">
-                <div className="h-12 w-12 rounded-lg bg-purple-900/30 flex items-center justify-center mb-4 group-hover:bg-purple-800/50 transition-colors">
-                  <svg className="h-6 w-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
-                  </svg>
+                <div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 4 }}>
+                    <span style={{ fontFamily: 'var(--ts-font-display)', fontSize: 18, color: 'var(--ts-ink)' }}>{track.label}</span>
+                    {track.complete && (
+                      <span style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 8, letterSpacing: '0.2em', color: 'var(--ts-amber)', border: '1px solid var(--ts-amber)', padding: '1px 5px' }}>COMPLETE</span>
+                    )}
+                  </div>
+                  <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-ink-3)', letterSpacing: '0.08em', marginBottom: 8 }}>{track.desc}</div>
+                  <div style={{ height: 2, background: 'var(--ts-line)', position: 'relative' }}>
+                    <div style={{ position: 'absolute', left: 0, top: 0, height: '100%', width: `${track.progress}%`, background: track.complete ? 'var(--ts-amber)' : 'var(--ts-blue)' }} />
+                  </div>
                 </div>
-                <h3 className="text-xl font-bold mb-2 text-white">AI Companion <span className="text-xs text-gray-500">(Coming Soon)</span></h3>
-                <p className="text-gray-400 mb-4">
-                  Get deck suggestions and playtest your strategies against our AI opponent.
-                </p>
-                <span className="text-gray-500 inline-flex items-center">
-                  In Development
-                </span>
-              </CardContent>
-            </Card>
+                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 22, color: track.complete ? 'var(--ts-amber)' : 'var(--ts-ink-3)', minWidth: 48, textAlign: 'right' }}>
+                  {track.progress}%
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
-      {/* Community Section */}
-      <section className="py-16 px-4">
-        <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-4xl font-bold mb-6 text-white">Join the Community</h2>
-          <p className="text-xl text-gray-300 mb-10">
-            Connect with other Star Wars Unlimited players, share your decks, and discover new strategies.
-          </p>
-          <Button asChild className="bg-transparent border border-pink-500 text-pink-500 hover:bg-pink-500/10 py-6 px-8 text-lg">
-          <Link href="/cards">
-            <svg className="w-5 h-5 mr-2 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16m-7 6h7" />
-            </svg>
-            Browse Cards
-          </Link>
-        </Button>
+      {/* ══ ASPECTS ══════════════════════════════════════════════════════ */}
+      <section style={{ borderTop: '1px solid var(--ts-line)', background: 'var(--ts-bg-2)', padding: '72px 48px' }}>
+        <div style={{ maxWidth: 1320, margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 60, alignItems: 'start' }}>
+          <div>
+            <div className="ts-eyebrow" style={{ marginBottom: 16 }}>Aspects</div>
+            <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 36, color: 'var(--ts-ink)', lineHeight: 1.1, marginBottom: 20 }}>
+              Six aspects.<br />Infinite strategies.
+            </div>
+            <p style={{ color: 'var(--ts-ink-2)', fontSize: 14, lineHeight: 1.75, fontFamily: 'var(--ts-font-body)' }}>
+              Every deck is defined by the aspects of its leader and base. Twin Suns rewards deep aspect knowledge — filter and build by aspect to find the synergies that win games.
+            </p>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1, background: 'var(--ts-line)' }}>
+            {ASPECTS_GRID.map(a => (
+              <div key={a.name} style={{ background: 'var(--ts-bg-2)', padding: '28px 24px', display: 'flex', alignItems: 'flex-start', gap: 14 }}>
+                <span style={{ width: 18, height: 18, background: ASPECT_COLORS[a.name] ?? '#555', clipPath: 'polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)', flexShrink: 0, marginTop: 3, display: 'inline-block' }} />
+                <div>
+                  <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 18, color: 'var(--ts-ink)', marginBottom: 4 }}>{a.name}</div>
+                  <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-ink-4)', letterSpacing: '0.14em', textTransform: 'uppercase' }}>{a.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
+
+      {/* ══ COMING SOON ══════════════════════════════════════════════════ */}
+      <section style={{ borderTop: '1px solid var(--ts-line)', padding: '64px 48px' }}>
+        <div style={{ maxWidth: 1320, margin: '0 auto' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 40 }}>
+            <div>
+              <div className="ts-eyebrow" style={{ marginBottom: 10 }}>On the Horizon</div>
+              <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 32, color: 'var(--ts-ink)' }}>Incoming transmissions</div>
+            </div>
+            <span style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-ink-4)', textTransform: 'uppercase' }}>In development</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 1, background: 'var(--ts-line)' }}>
+            {COMING_SOON.map(item => (
+              <div key={item.label} style={{ background: 'var(--ts-bg)', padding: '28px 24px', position: 'relative' }}>
+                <div style={{ position: 'absolute', top: 12, right: 14, fontFamily: 'var(--ts-font-mono)', fontSize: 8, letterSpacing: '0.2em', color: 'var(--ts-ink-4)', border: '1px solid var(--ts-line-2)', padding: '2px 6px' }}>SOON</div>
+                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 20, color: 'var(--ts-ink-2)', marginBottom: 8 }}>{item.label}</div>
+                <p style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-4)', letterSpacing: '0.08em', lineHeight: 1.6, margin: 0 }}>{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ══ FOOTER CTA ═══════════════════════════════════════════════════ */}
+      <section style={{ borderTop: '1px solid var(--ts-line)', background: 'var(--ts-bg-2)', padding: '80px 48px', textAlign: 'center' }}>
+        <div className="ts-eyebrow" style={{ marginBottom: 20 }}>Begin your briefing</div>
+        <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 'clamp(32px, 4vw, 52px)', color: 'var(--ts-ink)', marginBottom: 36, lineHeight: 1.1 }}>
+          Ready to build your roster?
+        </div>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Link href="/deck-builder" className="ts-btn ts-btn-primary" style={{ fontSize: 12, letterSpacing: '0.22em', padding: '12px 24px' }}>
+            OPEN DECK ATELIER →
+          </Link>
+          <Link href="/signup" className="ts-btn" style={{ fontSize: 12, letterSpacing: '0.22em', padding: '12px 24px' }}>
+            CREATE ACCOUNT
+          </Link>
+        </div>
+        <p style={{ marginTop: 32, fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-4)', letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+          Free · No ads · Star Wars Unlimited · Twin Suns Format
+        </p>
+      </section>
+
     </div>
   );
 }

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -252,6 +252,145 @@ const CollectionCard = ({
     );
 };
 
+// ── Coming Soon placeholder panel ─────────────────────────
+function ComingSoonPanel({
+    title,
+    description,
+    features,
+}: {
+    title: string;
+    description: string;
+    features: string[];
+}) {
+    return (
+        <div
+            style={{
+                position: 'relative',
+                minHeight: 400,
+                border: '1px solid var(--ts-line)',
+                background: 'var(--ts-panel)',
+                overflow: 'hidden',
+            }}
+        >
+            {/* Ghost preview content */}
+            <div style={{ padding: 32, opacity: 0.15, pointerEvents: 'none', userSelect: 'none' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+                    {[1, 2, 3, 4, 5, 6].map(i => (
+                        <div
+                            key={i}
+                            style={{
+                                height: 96,
+                                background: 'var(--ts-panel-2)',
+                                border: '1px solid var(--ts-line-2)',
+                            }}
+                        />
+                    ))}
+                </div>
+            </div>
+
+            {/* Overlay */}
+            <div
+                style={{
+                    position: 'absolute',
+                    inset: 0,
+                    background: 'rgba(26,22,17,0.90)',
+                    backdropFilter: 'blur(3px)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 40,
+                    textAlign: 'center',
+                }}
+            >
+                {/* Stamp */}
+                <div
+                    style={{
+                        fontFamily: 'var(--ts-font-mono)',
+                        fontSize: 10,
+                        letterSpacing: '0.28em',
+                        textTransform: 'uppercase',
+                        color: 'var(--ts-amber)',
+                        border: '1.5px solid var(--ts-amber)',
+                        padding: '4px 14px',
+                        marginBottom: 24,
+                        transform: 'rotate(-1deg)',
+                        opacity: 0.9,
+                    }}
+                >
+                    Coming Soon
+                </div>
+
+                <div
+                    style={{
+                        fontFamily: 'var(--ts-font-display)',
+                        fontSize: 32,
+                        color: 'var(--ts-ink)',
+                        marginBottom: 12,
+                        letterSpacing: '0.02em',
+                    }}
+                >
+                    {title}
+                </div>
+
+                <p
+                    style={{
+                        color: 'var(--ts-ink-2)',
+                        fontSize: 14,
+                        lineHeight: 1.7,
+                        maxWidth: 540,
+                        margin: '0 0 28px',
+                    }}
+                >
+                    {description}
+                </p>
+
+                {/* Feature list */}
+                <div
+                    style={{
+                        border: '1px solid var(--ts-line-2)',
+                        padding: '16px 24px',
+                        textAlign: 'left',
+                        maxWidth: 480,
+                        width: '100%',
+                    }}
+                >
+                    <div
+                        style={{
+                            fontFamily: 'var(--ts-font-mono)',
+                            fontSize: 9,
+                            letterSpacing: '0.2em',
+                            textTransform: 'uppercase',
+                            color: 'var(--ts-ink-3)',
+                            marginBottom: 12,
+                        }}
+                    >
+                        Planned Features
+                    </div>
+                    {features.map(f => (
+                        <div
+                            key={f}
+                            style={{
+                                display: 'flex',
+                                alignItems: 'flex-start',
+                                gap: 10,
+                                marginBottom: 8,
+                                fontFamily: 'var(--ts-font-mono)',
+                                fontSize: 11,
+                                color: 'var(--ts-ink-2)',
+                                lineHeight: 1.5,
+                            }}
+                        >
+                            <span style={{ color: 'var(--ts-amber)', flexShrink: 0, marginTop: 1 }}>◈</span>
+                            {f}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
 const ErrorMessage = ({ message, retryFn }: { message: string, retryFn: () => void }) => (
     <div className="bg-red-900/20 border border-red-800 rounded-lg p-4 text-center">
         <div className="flex justify-center mb-2">
@@ -271,14 +410,133 @@ interface UserProfileData {
     createdAt: string;
 }
 
+interface WishlistItem {
+    card: {
+        id: string;
+        name: string;
+        type?: string;
+        image_uri?: string;
+        energy_cost?: number;
+        set_name?: string;
+        aspects?: Array<{ aspect_name: string; aspect_color?: string }>;
+    };
+    added_at: string | null;
+}
+
+const ASPECT_COLORS: Record<string, string> = {
+    Command: '#c2453a', Aggression: '#d96f2d', Cunning: '#e2b342',
+    Heroism: '#ead7a8', Vigilance: '#4a90c4', Villainy: '#2c2a26',
+};
+
+function WishlistCard({ item, onRemove }: { item: WishlistItem; onRemove: (cardId: string) => void }) {
+    const { card } = item;
+    const aspects = card.aspects ?? [];
+    const bg =
+        aspects.length === 1
+            ? `linear-gradient(155deg, ${ASPECT_COLORS[aspects[0].aspect_name] ?? '#2c251a'}, #2c251a)`
+            : aspects.length >= 2
+            ? `linear-gradient(155deg, ${aspects.map(a => ASPECT_COLORS[a.aspect_name] ?? '#2c251a').join(', ')})`
+            : 'linear-gradient(155deg, #2c251a, #1f1a12)';
+
+    return (
+        <div
+            style={{
+                background: bg,
+                border: '1px solid var(--ts-line-2)',
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                boxShadow: '0 4px 14px rgba(0,0,0,0.35)',
+            }}
+        >
+            {/* Card art / placeholder */}
+            <div style={{ aspectRatio: '5/7', position: 'relative', overflow: 'hidden' }}>
+                {card.image_uri ? (
+                    <img
+                        src={card.image_uri}
+                        alt={card.name}
+                        style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                    />
+                ) : (
+                    <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <span style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'rgba(255,255,255,0.15)' }}>
+                            {card.name[0]}
+                        </span>
+                    </div>
+                )}
+                {/* Remove button */}
+                <button
+                    onClick={() => onRemove(card.id)}
+                    style={{
+                        position: 'absolute',
+                        top: 6,
+                        right: 6,
+                        width: 22,
+                        height: 22,
+                        background: 'rgba(10,8,4,0.82)',
+                        border: '1px solid rgba(255,255,255,0.2)',
+                        color: 'var(--ts-red)',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: 12,
+                        lineHeight: 1,
+                    }}
+                    title="Remove from wishlist"
+                >
+                    ✕
+                </button>
+            </div>
+
+            {/* Name plate */}
+            <div
+                style={{
+                    padding: '6px 8px',
+                    background: 'rgba(20,16,10,0.92)',
+                    borderTop: '1px solid rgba(255,255,255,0.1)',
+                }}
+            >
+                <div
+                    style={{
+                        fontFamily: 'var(--ts-font-display)',
+                        fontSize: 11,
+                        color: '#e8dcc4',
+                        overflow: 'hidden',
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        lineHeight: 1.3,
+                    }}
+                >
+                    {card.name}
+                </div>
+                <div
+                    style={{
+                        fontFamily: 'var(--ts-font-mono)',
+                        fontSize: 8,
+                        color: 'rgba(255,255,255,0.4)',
+                        letterSpacing: '0.1em',
+                        textTransform: 'uppercase',
+                        marginTop: 2,
+                    }}
+                >
+                    {card.type}
+                </div>
+            </div>
+        </div>
+    );
+}
+
 const UserProfilePage = () => {
     const router = useRouter();
     const { user, isAuthenticated, isLoading: authLoading } = useAuth();
-    
+
     // State
     const [decks, setDecks] = useState<SavedDeck[]>([]);
     const [collection, setCollection] = useState<CollectionItem[]>([]);
-    const [isPageLoading, setIsPageLoading] = useState(true);  
+    const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
+    const [isPageLoading, setIsPageLoading] = useState(true);
     const [userProfile, setUserProfile] = useState<UserProfileData>(user ? {
         id: user.id,
         username: user.username,
@@ -345,8 +603,19 @@ const UserProfilePage = () => {
             console.error('[Profile] Error fetching collection:', collectionError);
           }
           
+          let wishlistData: WishlistItem[] = [];
+          try {
+            const wishlistResponse = await fetch('/api/me/wishlist');
+            if (wishlistResponse.ok) {
+              wishlistData = await wishlistResponse.json();
+            }
+          } catch (wishlistError) {
+            console.error('[Profile] Error fetching wishlist:', wishlistError);
+          }
+
           setDecks(decksData);
           setCollection(collectionData);
+          setWishlist(wishlistData);
         } catch (err) {
           console.error('[Profile] Error loading profile data:', err);
           setError('Failed to load profile data. Please check your connection and try again.');
@@ -441,10 +710,26 @@ const UserProfilePage = () => {
         });
     };
 
+    const handleRemoveFromWishlist = async (cardId: string) => {
+        try {
+            const res = await fetch(`/api/me/wishlist/${cardId}`, { method: 'DELETE' });
+            if (res.ok || res.status === 204) {
+                setWishlist(prev => prev.filter(item => item.card.id !== cardId));
+            }
+        } catch (err) {
+            console.error('Error removing from wishlist:', err);
+        }
+    };
+
     // Filtered collection based on search
     const filteredCollection = collection.filter((item) =>
         item.card.name.toLowerCase().includes(searchTerm.toLowerCase())
     );
+
+    // Collection completion stats (available when showAllCards=true)
+    const ownedCount = collection.filter(item => item.in_collection).length;
+    const totalCount = collection.length;
+    const completionPct = totalCount > 0 ? ((ownedCount / totalCount) * 100).toFixed(1) : null;
 
     return (
         <div className="min-h-screen bg-gray-950 text-white">
@@ -475,6 +760,20 @@ const UserProfilePage = () => {
                                 </span>
                             </div>
                         </div>
+                        {/* Collection completion stat */}
+                        {completionPct !== null && (
+                            <div style={{ marginLeft: 24, padding: '10px 18px', background: 'var(--ts-bg-2)', border: '1px solid var(--ts-line)', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 8, letterSpacing: '0.2em', color: 'var(--ts-ink-4)', textTransform: 'uppercase' }}>
+                                    Collection
+                                </div>
+                                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 22, color: 'var(--ts-amber)', lineHeight: 1 }}>
+                                    {completionPct}%
+                                </div>
+                                <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 8, color: 'var(--ts-ink-4)', letterSpacing: '0.1em' }}>
+                                    {ownedCount} / {totalCount} cards
+                                </div>
+                            </div>
+                        )}
                     </div>
                     {isEditing ? (
                         <div className="flex gap-2">
@@ -506,7 +805,7 @@ const UserProfilePage = () => {
             {/* Main Content */}
             <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 <Tabs defaultValue="decks" className="w-full" onValueChange={setSelectedTab}>
-                    <TabsList className="grid w-full grid-cols-2 mb-8 bg-gray-900 border-b border-gray-800">
+                    <TabsList className="grid w-full grid-cols-5 mb-8 bg-gray-900 border-b border-gray-800">
                         <TabsTrigger
                             value="decks"
                             className={cn(
@@ -530,6 +829,39 @@ const UserProfilePage = () => {
                         >
                             <Library className="w-5 h-5" />
                             My Collection
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="achievements"
+                            className={cn(
+                                "text-lg font-semibold data-[state=active]:text-white data-[state=active]:bg-gray-800",
+                                "data-[state=inactive]:text-gray-400 data-[state=inactive]:hover:text-white",
+                                "transition-colors duration-200 py-4 px-6",
+                                "flex items-center gap-2"
+                            )}
+                        >
+                            Achievements
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="tournaments"
+                            className={cn(
+                                "text-lg font-semibold data-[state=active]:text-white data-[state=active]:bg-gray-800",
+                                "data-[state=inactive]:text-gray-400 data-[state=inactive]:hover:text-white",
+                                "transition-colors duration-200 py-4 px-6",
+                                "flex items-center gap-2"
+                            )}
+                        >
+                            Tournaments
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="wishlist"
+                            className={cn(
+                                "text-lg font-semibold data-[state=active]:text-white data-[state=active]:bg-gray-800",
+                                "data-[state=inactive]:text-gray-400 data-[state=inactive]:hover:text-white",
+                                "transition-colors duration-200 py-4 px-6",
+                                "flex items-center gap-2"
+                            )}
+                        >
+                            Wishlist
                         </TabsTrigger>
                     </TabsList>
                     <TabsContent value="decks">
@@ -651,6 +983,105 @@ const UserProfilePage = () => {
                                         </Button>
                                     </>
                                 )}
+                            </div>
+                        )}
+                    </TabsContent>
+
+                    {/* ── Achievements — Coming Soon ─────────────────────── */}
+                    <TabsContent value="achievements">
+                        <ComingSoonPanel
+                            title="Achievements & Pilot Training"
+                            description="Earn badges for deck-building milestones, tournament finishes, and collection goals. Pilot Training will guide new players through Twin Suns fundamentals with guided challenges."
+                            features={[
+                                'Milestone badges (first deck, first win, 100-card collection…)',
+                                'Pilot Training — guided challenges for new Twin Suns players',
+                                'Seasonal achievement tracks',
+                                'Badge showcase on your public profile',
+                            ]}
+                        />
+                    </TabsContent>
+
+                    {/* ── Tournament History — Coming Soon ──────────────── */}
+                    <TabsContent value="tournaments">
+                        <ComingSoonPanel
+                            title="Tournament History"
+                            description="Track your event results, ELO rating, and head-to-head records. Requires a tournament-reporting integration — planned for a future release."
+                            features={[
+                                'Event results with placement and record',
+                                'ELO / ranking history over time',
+                                'Head-to-head records vs opponents',
+                                'Deck used per event with performance breakdown',
+                            ]}
+                        />
+                    </TabsContent>
+
+                    {/* ── Wishlist ─────────────────────────────────────── */}
+                    <TabsContent value="wishlist">
+                        <div style={{ marginBottom: 28, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <div>
+                                <div className="ts-eyebrow" style={{ marginBottom: 4 }}>Acquisition List</div>
+                                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'var(--ts-ink)' }}>
+                                    Wishlist
+                                </div>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                                {wishlist.length > 0 && (
+                                    <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-3)', letterSpacing: '0.14em' }}>
+                                        {wishlist.length} {wishlist.length === 1 ? 'card' : 'cards'}
+                                    </div>
+                                )}
+                                <a
+                                    href="/cards"
+                                    className="ts-btn ts-btn-primary ts-btn-sm"
+                                    style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+                                >
+                                    + Browse Cards
+                                </a>
+                            </div>
+                        </div>
+
+                        {isPageLoading ? (
+                            <div style={{ textAlign: 'center', padding: '64px 0', color: 'var(--ts-ink-3)', fontFamily: 'var(--ts-font-mono)', fontSize: 11, letterSpacing: '0.16em' }}>
+                                LOADING…
+                            </div>
+                        ) : wishlist.length === 0 ? (
+                            <div
+                                style={{
+                                    border: '1px solid var(--ts-line)',
+                                    padding: '64px 32px',
+                                    textAlign: 'center',
+                                    background: 'var(--ts-bg-2)',
+                                }}
+                            >
+                                <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 28, color: 'var(--ts-ink-3)', marginBottom: 12 }}>
+                                    Nothing on the list yet.
+                                </div>
+                                <p style={{ color: 'var(--ts-ink-3)', fontSize: 13, lineHeight: 1.7, maxWidth: 400, margin: '0 auto 24px' }}>
+                                    Browse the card catalogue and add cards you're hunting to your wishlist.
+                                </p>
+                                <a
+                                    href="/cards"
+                                    className="ts-btn ts-btn-primary"
+                                    style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+                                >
+                                    Browse Cards →
+                                </a>
+                            </div>
+                        ) : (
+                            <div
+                                style={{
+                                    display: 'grid',
+                                    gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+                                    gap: 12,
+                                }}
+                            >
+                                {wishlist.map(item => (
+                                    <WishlistCard
+                                        key={item.card.id}
+                                        item={item}
+                                        onRemove={handleRemoveFromWishlist}
+                                    />
+                                ))}
                             </div>
                         )}
                     </TabsContent>

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -4,237 +4,147 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertTriangle, Check } from "lucide-react";
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function SignupPage() {
-    const router = useRouter();
-    const { register } = useAuth();
-    const [formData, setFormData] = useState({
-        username: '',
-        email: '',
-        password: '',
-        confirmPassword: ''
-    });
-    const [errors, setErrors] = useState<Record<string, string>>({});
-    const [isLoading, setIsLoading] = useState(false);
-    const [success, setSuccess] = useState(false);
-    const [serverError, setServerError] = useState<string | null>(null);
+  const router = useRouter();
+  const { register } = useAuth();
 
-    // Handle form input changes
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({ ...prev, [name]: value }));
-        
-        // Clear errors when user types
-        if (errors[name]) {
-            setErrors(prev => {
-                const newErrors = { ...prev };
-                delete newErrors[name];
-                return newErrors;
-            });
-        }
-    };
+  const [formData, setFormData] = useState({ username: '', email: '', password: '', confirmPassword: '' });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
 
-    // Validate form inputs
-    const validateForm = (): boolean => {
-        const newErrors: Record<string, string> = {};
-        
-        // Username validation
-        if (!formData.username) {
-            newErrors.username = "Username is required";
-        } else if (formData.username.length < 3) {
-            newErrors.username = "Username must be at least 3 characters";
-        } else if (!/^[a-zA-Z0-9_]+$/.test(formData.username)) {
-            newErrors.username = "Username can only contain letters, numbers, and underscores";
-        }
-        
-        // Email validation
-        if (!formData.email) {
-            newErrors.email = "Email is required";
-        } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
-            newErrors.email = "Please enter a valid email address";
-        }
-        
-        // Password validation
-        if (!formData.password) {
-            newErrors.password = "Password is required";
-        } else if (formData.password.length < 8) {
-            newErrors.password = "Password must be at least 8 characters";
-        }
-        
-        // Confirm password validation
-        if (formData.password !== formData.confirmPassword) {
-            newErrors.confirmPassword = "Passwords do not match";
-        }
-        
-        setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    if (errors[name]) setErrors(prev => { const n = { ...prev }; delete n[name]; return n; });
+  };
 
-    // Handle form submission
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setServerError(null);
-        
-        // Validate form
-        if (!validateForm()) {
-            return;
-        }
-        
-        setIsLoading(true);
-        
-        try {
-            await register(formData.username, formData.email, formData.password);
-            
-            // Show success message
-            setSuccess(true);
-            
-            // Redirect to login page after a short delay
-            setTimeout(() => {
-                router.push('/login');
-            }, 2000);
-            
-        } catch (err: any) {
-            console.error("Signup error:", err);
-            setServerError(err.message || "An unexpected error occurred during signup");
-        } finally {
-            setIsLoading(false);
-        }
-    };
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!formData.username) newErrors.username = 'Callsign is required';
+    else if (formData.username.length < 3) newErrors.username = 'Callsign must be at least 3 characters';
+    else if (!/^[a-zA-Z0-9_]+$/.test(formData.username)) newErrors.username = 'Letters, numbers, and underscores only';
+    if (!formData.email) newErrors.email = 'Email is required';
+    else if (!/\S+@\S+\.\S+/.test(formData.email)) newErrors.email = 'Enter a valid email address';
+    if (!formData.password) newErrors.password = 'Password is required';
+    else if (formData.password.length < 8) newErrors.password = 'Minimum 8 characters';
+    if (formData.password !== formData.confirmPassword) newErrors.confirmPassword = 'Passwords do not match';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
 
-    return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-950 p-4">
-            <Card className="w-full max-w-md bg-gray-900 border-gray-800 text-white">
-                <CardHeader>
-                    <CardTitle className="text-2xl font-bold text-center">
-                        <span className="bg-gradient-to-r from-purple-500 via-pink-500 to-orange-500 bg-clip-text text-transparent">
-                            Create Your Account
-                        </span>
-                    </CardTitle>
-                    <CardDescription className="text-gray-400 text-center">
-                        Join the Star Wars Unlimited community and start building decks
-                    </CardDescription>
-                </CardHeader>
-                
-                <CardContent>
-                    {/* Success message */}
-                    {success && (
-                        <Alert className="mb-6 bg-green-900/30 border-green-800 text-green-300">
-                            <Check className="h-4 w-4" />
-                            <AlertTitle>Success!</AlertTitle>
-                            <AlertDescription>
-                                Your account has been created. Redirecting to login...
-                            </AlertDescription>
-                        </Alert>
-                    )}
-                    
-                    {/* Error message */}
-                    {serverError && (
-                        <Alert className="mb-6 bg-red-900/30 border-red-800 text-red-300">
-                            <AlertTriangle className="h-4 w-4" />
-                            <AlertTitle>Registration Failed</AlertTitle>
-                            <AlertDescription>{serverError}</AlertDescription>
-                        </Alert>
-                    )}
-                    
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        {/* Username field */}
-                        <div className="space-y-2">
-                            <Label htmlFor="username">Username</Label>
-                            <Input
-                                id="username"
-                                name="username"
-                                type="text"
-                                placeholder="Enter your username"
-                                value={formData.username}
-                                onChange={handleChange}
-                                className={`bg-gray-800 border ${errors.username ? 'border-red-500' : 'border-gray-700'}`}
-                                disabled={isLoading || success}
-                            />
-                            {errors.username && (
-                                <p className="text-red-500 text-sm">{errors.username}</p>
-                            )}
-                        </div>
-                        
-                        {/* Email field */}
-                        <div className="space-y-2">
-                            <Label htmlFor="email">Email</Label>
-                            <Input
-                                id="email"
-                                name="email"
-                                type="email"
-                                placeholder="Enter your email"
-                                value={formData.email}
-                                onChange={handleChange}
-                                className={`bg-gray-800 border ${errors.email ? 'border-red-500' : 'border-gray-700'}`}
-                                disabled={isLoading || success}
-                            />
-                            {errors.email && (
-                                <p className="text-red-500 text-sm">{errors.email}</p>
-                            )}
-                        </div>
-                        
-                        {/* Password field */}
-                        <div className="space-y-2">
-                            <Label htmlFor="password">Password</Label>
-                            <Input
-                                id="password"
-                                name="password"
-                                type="password"
-                                placeholder="Create a password"
-                                value={formData.password}
-                                onChange={handleChange}
-                                className={`bg-gray-800 border ${errors.password ? 'border-red-500' : 'border-gray-700'}`}
-                                disabled={isLoading || success}
-                            />
-                            {errors.password && (
-                                <p className="text-red-500 text-sm">{errors.password}</p>
-                            )}
-                        </div>
-                        
-                        {/* Confirm Password field */}
-                        <div className="space-y-2">
-                            <Label htmlFor="confirmPassword">Confirm Password</Label>
-                            <Input
-                                id="confirmPassword"
-                                name="confirmPassword"
-                                type="password"
-                                placeholder="Confirm your password"
-                                value={formData.confirmPassword}
-                                onChange={handleChange}
-                                className={`bg-gray-800 border ${errors.confirmPassword ? 'border-red-500' : 'border-gray-700'}`}
-                                disabled={isLoading || success}
-                            />
-                            {errors.confirmPassword && (
-                                <p className="text-red-500 text-sm">{errors.confirmPassword}</p>
-                            )}
-                        </div>
-                        
-                        <Button
-                            type="submit"
-                            className="w-full bg-purple-600 hover:bg-purple-700 text-white"
-                            disabled={isLoading || success}
-                        >
-                            {isLoading ? 'Creating Account...' : 'Sign Up'}
-                        </Button>
-                    </form>
-                </CardContent>
-                
-                <CardFooter className="flex justify-center">
-                    <p className="text-gray-400">
-                        Already have an account?{' '}
-                        <Link href="/login" className="text-purple-400 hover:underline">
-                            Log In
-                        </Link>
-                    </p>
-                </CardFooter>
-            </Card>
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setServerError(null);
+    if (!validateForm()) return;
+    setIsLoading(true);
+    try {
+      await register(formData.username, formData.email, formData.password);
+      setSuccess(true);
+      setTimeout(() => router.push('/login'), 2000);
+    } catch (err: unknown) {
+      setServerError(err instanceof Error ? err.message : 'An unexpected error occurred during signup');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const field = (
+    id: string, label: string, type: string, placeholder: string,
+    value: string, autoComplete?: string
+  ) => (
+    <div style={{ marginBottom: 20 }}>
+      <label htmlFor={id} style={{ display: 'block', fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-ink-3)', textTransform: 'uppercase', marginBottom: 8 }}>
+        {label}
+      </label>
+      <input
+        id={id} name={id} type={type} placeholder={placeholder} value={value}
+        onChange={handleChange} disabled={isLoading || success}
+        autoComplete={autoComplete}
+        className="ts-input"
+        style={{ width: '100%', borderColor: errors[id] ? 'var(--ts-red)' : undefined }}
+        required
+      />
+      {errors[id] && (
+        <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-red)', letterSpacing: '0.1em', marginTop: 6 }}>
+          ⚠ {errors[id]}
         </div>
-    );
+      )}
+    </div>
+  );
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--ts-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '40px 24px' }}>
+      <div style={{ width: '100%', maxWidth: 420 }}>
+
+        {/* Header */}
+        <div style={{ marginBottom: 40, textAlign: 'center' }}>
+          <div className="ts-eyebrow" style={{ marginBottom: 12 }}>Twin Suns · Enlistment</div>
+          <div style={{ fontFamily: 'var(--ts-font-display)', fontSize: 36, color: 'var(--ts-ink)', lineHeight: 1.1 }}>
+            Join the squadron.
+          </div>
+        </div>
+
+        {/* Card */}
+        <div style={{ background: 'var(--ts-bg-2)', border: '1px solid var(--ts-line)', padding: '36px 32px' }}>
+
+          {success && (
+            <div style={{ marginBottom: 24, padding: '12px 16px', border: '1px solid var(--ts-green)', background: 'rgba(110,227,107,0.08)' }}>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-green)', marginBottom: 4, textTransform: 'uppercase' }}>
+                Enlisted
+              </div>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 11, color: 'rgba(110,227,107,0.9)', letterSpacing: '0.06em' }}>
+                Account created. Redirecting to login...
+              </div>
+            </div>
+          )}
+
+          {serverError && (
+            <div style={{ marginBottom: 24, padding: '12px 16px', border: '1px solid var(--ts-red)', background: 'rgba(255,61,46,0.08)' }}>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 9, letterSpacing: '0.2em', color: 'var(--ts-red)', marginBottom: 4, textTransform: 'uppercase' }}>
+                Enlistment Failed
+              </div>
+              <div style={{ fontFamily: 'var(--ts-font-mono)', fontSize: 11, color: 'rgba(255,100,90,0.9)', letterSpacing: '0.06em' }}>
+                {serverError}
+              </div>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            {field('username', 'Callsign', 'text', 'Choose a username', formData.username, 'username')}
+            {field('email', 'Comm Channel', 'email', 'Enter your email', formData.email, 'email')}
+            {field('password', 'Security Code', 'password', 'Minimum 8 characters', formData.password, 'new-password')}
+            {field('confirmPassword', 'Confirm Code', 'password', 'Repeat your password', formData.confirmPassword, 'new-password')}
+
+            <div style={{ marginTop: 8 }}>
+              <button
+                type="submit"
+                className="ts-btn ts-btn-primary"
+                style={{ width: '100%', justifyContent: 'center', fontSize: 11, letterSpacing: '0.22em', padding: '14px 24px', opacity: isLoading || success ? 0.6 : 1 }}
+                disabled={isLoading || success}
+              >
+                {isLoading ? 'PROCESSING...' : 'ENLIST NOW →'}
+              </button>
+            </div>
+          </form>
+
+          <div className="ts-rule" style={{ margin: '24px 0' }} />
+
+          <div style={{ textAlign: 'center', fontFamily: 'var(--ts-font-mono)', fontSize: 10, color: 'var(--ts-ink-3)', letterSpacing: '0.12em' }}>
+            Already enlisted?{' '}
+            <Link href="/login" style={{ color: 'var(--ts-amber)', textDecoration: 'none' }}>
+              Sign in
+            </Link>
+          </div>
+        </div>
+
+        <div style={{ marginTop: 24, textAlign: 'center', fontFamily: 'var(--ts-font-mono)', fontSize: 9, color: 'var(--ts-ink-4)', letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+          Twin Suns · Star Wars Unlimited · Twin Suns Format
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/CardDetailDialog.tsx
+++ b/frontend/src/components/CardDetailDialog.tsx
@@ -21,6 +21,8 @@ export function CardDetailDialog({ card, onClose }: CardDetailDialogProps) {
   const [addedToCollection, setAddedToCollection] = useState(false);
   const [isInCollection, setIsInCollection] = useState(false);
   const [addMessage, setAddMessage] = useState('');
+  const [onWishlist, setOnWishlist] = useState(false);
+  const [wishlistLoading, setWishlistLoading] = useState(false);
 
   // Only allow flipping for cards with a back side (mainly Leaders)
   const canFlip = card?.image_back_uri !== undefined && card?.image_back_uri !== null;
@@ -34,6 +36,28 @@ export function CardDetailDialog({ card, onClose }: CardDetailDialogProps) {
     } else {
       // For non-leaders, we'll need to select a leader first
       router.push('/deck-builder');
+    }
+  };
+
+  const handleToggleWishlist = async () => {
+    try {
+      setWishlistLoading(true);
+      if (onWishlist) {
+        await fetch(`/api/me/wishlist/${card.id}`, { method: 'DELETE', credentials: 'include' });
+        setOnWishlist(false);
+      } else {
+        await fetch('/api/me/wishlist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ card_id: card.id }),
+        });
+        setOnWishlist(true);
+      }
+    } catch (err) {
+      console.error('Error toggling wishlist:', err);
+    } finally {
+      setWishlistLoading(false);
     }
   };
 
@@ -255,6 +279,15 @@ export function CardDetailDialog({ card, onClose }: CardDetailDialogProps) {
           )}
         </Button>
         
+        <Button
+          onClick={handleToggleWishlist}
+          disabled={wishlistLoading}
+          variant="outline"
+          className={`border-amber-700 text-amber-400 hover:bg-amber-900/30 ${onWishlist ? 'bg-amber-900/30' : ''}`}
+        >
+          {onWishlist ? '★ On Wishlist' : '☆ Add to Wishlist'}
+        </Button>
+
         <Button
           onClick={onClose}
           variant="outline"

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,104 +1,339 @@
 // src/components/Navbar.tsx
 'use client';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button'; // Import your Button component
 import { useAuth } from '@/contexts/AuthContext';
+
+function TwinSunsMark({ size = 28 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden>
+      <circle cx="14" cy="22" r="9" fill="var(--ts-amber)" opacity="0.9" />
+      <circle cx="27" cy="14" r="6" fill="var(--ts-red)" opacity="0.85" />
+      <circle cx="14" cy="22" r="9" fill="none" stroke="var(--ts-bg)" strokeWidth="0.5" />
+    </svg>
+  );
+}
+
+const STATUS_ITEMS = [
+  { tag: 'TRANS', text: 'Set 04 · Jump to Lightspeed now available' },
+  { tag: 'META',  text: 'Sabine Wren ▲ +4.2% · Boba Fett ▼ -1.8% · Luke (JK) holds #1' },
+  { tag: 'ALERT', text: "Errata posted for Vader's Lightsaber — see rulings index" },
+  { tag: 'EVENT', text: 'Galactic Championship Series · Qualifier 06.04' },
+];
+
+function StatusStrip() {
+  const loop = [...STATUS_ITEMS, ...STATUS_ITEMS];
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--ts-line)',
+        background: 'var(--ts-panel)',
+        overflow: 'hidden',
+        height: 30,
+        position: 'relative',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '100%',
+          fontFamily: 'var(--ts-font-mono)',
+          fontSize: 11,
+          letterSpacing: '0.08em',
+          color: 'var(--ts-ink-3)',
+        }}
+      >
+        {/* Left badge */}
+        <span
+          style={{
+            flexShrink: 0,
+            padding: '0 20px',
+            color: 'var(--ts-amber)',
+            fontWeight: 700,
+            letterSpacing: '0.18em',
+            borderRight: '1px solid var(--ts-line)',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            background: 'var(--ts-panel)',
+            zIndex: 2,
+            fontSize: 10,
+          }}
+        >
+          ◉ LIVE
+        </span>
+
+        {/* Marquee track */}
+        <div
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            position: 'relative',
+          }}
+        >
+          <div
+            className="ts-marquee-track"
+            style={{ display: 'flex', gap: 48, whiteSpace: 'nowrap', paddingLeft: 24 }}
+          >
+            {loop.map((item, i) => (
+              <span
+                key={i}
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 10, flexShrink: 0 }}
+              >
+                <span
+                  style={{
+                    fontSize: 9,
+                    padding: '1px 6px',
+                    border: '1px solid var(--ts-line-2)',
+                    color: 'var(--ts-ink-2)',
+                    letterSpacing: '0.2em',
+                  }}
+                >
+                  {item.tag}
+                </span>
+                <span>{item.text}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Right ABY date */}
+        <span
+          style={{
+            flexShrink: 0,
+            padding: '0 20px',
+            fontSize: 10,
+            color: 'var(--ts-ink-4)',
+            whiteSpace: 'nowrap',
+            borderLeft: '1px solid var(--ts-line)',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            background: 'var(--ts-panel)',
+            zIndex: 2,
+            letterSpacing: '0.1em',
+          }}
+        >
+          34 ABY
+        </span>
+      </div>
+    </div>
+  );
+}
 
 export function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { isAuthenticated } = useAuth(); // Add this line
-  
-  const isActive = (path: string) => pathname === path;
-  
-  // Logout function
+  const { isAuthenticated, user } = useAuth();
+
+  const isActive = (path: string) => pathname === path || pathname.startsWith(path + '/');
+
   const handleLogout = async () => {
     try {
-      // Call the logout endpoint
       await fetch('/api/auth/logout', { method: 'POST' });
-      
-      // Clear the auth token
-      document.cookie = "auth_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-      
-      // Redirect to login page
+      document.cookie = 'auth_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      localStorage.removeItem('auth_token');
       router.push('/login');
     } catch (err) {
       console.error('Logout error:', err);
     }
   };
-  
+
+  const navLinks = [
+    { href: '/cards', label: 'Cards' },
+    { href: '/deck-builder', label: 'Deck Builder' },
+    ...(isAuthenticated ? [{ href: '/profile', label: 'Profile' }] : []),
+  ];
+
+  const initials = user?.username
+    ? user.username.slice(0, 2).toUpperCase()
+    : '??';
+
   return (
-    <nav className="bg-gray-900 border-b border-gray-800 py-4 px-6">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
-        {/* Logo/Home link with gradient */}
-        <Link href="/" className="flex items-center">
-          <span className="text-2xl font-bold">
-            <span className="twin-suns-gradient">Twin Suns</span>
-          </span>
-        </Link>
-        
-        {/* Navigation Links */}
-        <div className="flex items-center space-x-6">
+    <header style={{ position: 'sticky', top: 0, zIndex: 100 }}>
+      {/* Main nav bar */}
+      <div
+        style={{
+          borderBottom: '1px solid var(--ts-line)',
+          background: 'var(--ts-bg)',
+          backdropFilter: 'blur(6px)',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 1320,
+            margin: '0 auto',
+            padding: '0 32px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            height: 60,
+            gap: 28,
+          }}
+        >
+          {/* Logo */}
           <Link
-            href="/cards"
-            className={`text-lg transition-colors ${
-              isActive('/cards')
-                ? 'text-purple-400 font-medium'
-                : 'text-gray-300 hover:text-white'
-            }`}
+            href="/"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              textDecoration: 'none',
+            }}
           >
-            Cards
+            <TwinSunsMark size={26} />
+            <div style={{ lineHeight: 1.1 }}>
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 9,
+                  letterSpacing: '0.26em',
+                  color: 'var(--ts-ink-3)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Star Wars Unlimited
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--ts-font-display)',
+                  fontSize: 18,
+                  color: 'var(--ts-ink)',
+                  letterSpacing: '0.04em',
+                }}
+              >
+                Twin&nbsp;Suns
+              </div>
+            </div>
           </Link>
-          
-          <Link
-            href="/deck-builder"
-            className={`text-lg transition-colors ${
-              isActive('/deck-builder')
-                ? 'text-purple-400 font-medium'
-                : 'text-gray-300 hover:text-white'
-            }`}
-          >
-            Deck Builder
-          </Link>
-          
-          {/* Conditionally render Profile and Login/Logout */}
-          {isAuthenticated ? (
-            <>
+
+          {/* Nav links */}
+          <nav style={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+            {navLinks.map((link) => (
               <Link
-                href="/profile"
-                className={`text-lg transition-colors ${
-                  isActive('/profile')
-                    ? 'text-purple-400 font-medium'
-                    : 'text-gray-300 hover:text-white'
-                }`}
+                key={link.href}
+                href={link.href}
+                style={{
+                  padding: '8px 14px',
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: '0.22em',
+                  textTransform: 'uppercase',
+                  color: isActive(link.href) ? 'var(--ts-amber)' : 'var(--ts-ink-2)',
+                  textDecoration: 'none',
+                  borderBottom: isActive(link.href)
+                    ? '2px solid var(--ts-amber)'
+                    : '2px solid transparent',
+                  transition: 'color 0.15s, border-color 0.15s',
+                }}
               >
-                Profile
+                {link.label}
               </Link>
-              
-              <Button 
-                onClick={handleLogout}
-                variant="ghost"
-                className="text-gray-300 hover:text-white"
+            ))}
+          </nav>
+
+          {/* Right: user */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            {isAuthenticated ? (
+              <>
+                <Link
+                  href="/profile"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    textDecoration: 'none',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 30,
+                      height: 30,
+                      background: 'var(--ts-panel-2)',
+                      border: '1px solid var(--ts-line-2)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontFamily: 'var(--ts-font-mono)',
+                      fontSize: 10,
+                      letterSpacing: '0.08em',
+                      color: 'var(--ts-amber)',
+                    }}
+                  >
+                    {initials}
+                  </div>
+                  <div style={{ lineHeight: 1.1 }}>
+                    <div style={{ fontSize: 12, color: 'var(--ts-ink)', fontFamily: 'var(--ts-font-mono)' }}>
+                      {user?.username ?? 'Commander'}
+                    </div>
+                    <div
+                      style={{
+                        fontFamily: 'var(--ts-font-mono)',
+                        fontSize: 9,
+                        letterSpacing: '0.14em',
+                        color: 'var(--ts-ink-3)',
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      Twin Suns
+                    </div>
+                  </div>
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  style={{
+                    padding: '6px 12px',
+                    fontFamily: 'var(--ts-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: '0.18em',
+                    textTransform: 'uppercase',
+                    border: '1px solid var(--ts-line-2)',
+                    background: 'transparent',
+                    color: 'var(--ts-ink-3)',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--ts-red)';
+                    (e.currentTarget as HTMLButtonElement).style.color = 'var(--ts-red)';
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--ts-line-2)';
+                    (e.currentTarget as HTMLButtonElement).style.color = 'var(--ts-ink-3)';
+                  }}
+                >
+                  Logout
+                </button>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                style={{
+                  padding: '7px 16px',
+                  fontFamily: 'var(--ts-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: '0.18em',
+                  textTransform: 'uppercase',
+                  border: '1px solid var(--ts-amber)',
+                  background: 'transparent',
+                  color: 'var(--ts-amber)',
+                  textDecoration: 'none',
+                  transition: 'all 0.15s',
+                }}
               >
-                Logout
-              </Button>
-            </>
-          ) : (
-            <Link
-              href="/login"
-              className={`text-lg transition-colors ${
-                isActive('/login')
-                  ? 'text-purple-400 font-medium'
-                  : 'text-gray-300 hover:text-white'
-              }`}
-            >
-              Login
-            </Link>
-          )}
+                Login
+              </Link>
+            )}
+          </div>
         </div>
       </div>
-    </nav>
+
+      <StatusStrip />
+    </header>
   );
 }


### PR DESCRIPTION
## Summary

- **Full design system replacement** — removes the original Tailwind/shadcn purple theme and implements the \"Imperial Field Manual\" Twin Suns visual identity across all pages (home, navbar, login, signup, deck builder, profile)
- **Twin suns hero** — home page gets the full hero treatment: absolute-positioned radial gradient suns, scanlines overlay, left vignette, correct copy and Spotlight/Pilot Training sections
- **Wishlist feature** — new full-stack wishlist: DB model, backend routes, Next.js proxy, profile tab UI, and card detail dialog button

## What changed

### Backend
- `backend/src/database/models.py`: `UserWishlist` model added (composite PK on `user_id` + `card_id`, `added_at` timestamp); relationships wired on `User` and `Card`; SQLAlchemy `create_all` will auto-create the table on next startup — no migration script needed
- `backend/src/routes/me.py`: three new routes — `GET /me/wishlist`, `POST /me/wishlist` (idempotent), `DELETE /me/wishlist/{card_id}`; returns enriched card data with aspect/keyword relationships

### Frontend — new files
- `frontend/src/app/api/me/wishlist/route.ts` — GET + POST proxy
- `frontend/src/app/api/me/wishlist/[cardId]/route.ts` — DELETE proxy (Next.js 15 `Promise<params>` pattern)
- `frontend/src/app/deck-builder/HandSimModal.tsx` — hand sim modal extracted as standalone component with editable opponent leader input
- `frontend/src/app/icon.svg` — twin suns favicon (amber + red circles, auto-served by Next.js App Router)

### Frontend — modified files
- `globals.css` / `layout.tsx`: Twin Suns CSS custom properties and font imports
- `page.tsx`: full home page rewrite with hero, spotlight, pilot training, aspects grid, footer
- `Navbar.tsx`: full redesign with Imperial Field Manual branding
- `login/page.tsx` + `signup/page.tsx`: restyled (callsign/security code labels, amber CTA buttons, error/success panels)
- `DeckBuilderClient.tsx`: design system integration
- `profile/page.tsx`: collection completion % stat chip; wishlist tab replaces Coming Soon with live card grid (aspect-gradient mini-cards, ✕ remove button, empty state)
- `CardDetailDialog.tsx`: wishlist toggle button (☆/★) added to dialog footer

## Reviewer notes

- The `user_wishlist` table is new — existing `swu_app.db` instances will get it created automatically on next backend start via `create_all`
- Pre-existing TypeScript errors in `decks/[id]/route.ts` (params type) and `DeckBuilderClient.tsx` (`power`/`hp` properties) are unchanged — not introduced by this PR
- Worktree dev server runs on `:3001` (`.claude/launch.json` updated) to avoid colliding with the main project on `:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)